### PR TITLE
feat(qwen-auth): add Qwen Auth plugin with OAuth Device Flow support

### DIFF
--- a/plugins/qwen-auth/README.md
+++ b/plugins/qwen-auth/README.md
@@ -1,0 +1,127 @@
+# Qwen Auth Plugin for Alma
+
+Use Alibaba Qwen AI models with Alma via OAuth Device Flow authentication.
+
+## Features
+
+- 🔐 **OAuth Device Flow**: Secure authentication using OAuth 2.0 Device Authorization Flow with PKCE
+- 🔄 **Automatic Token Refresh**: Tokens are automatically refreshed when expired
+- 🤖 **Multiple Models**: Access to Qwen3 Coder, Qwen3 Max, Qwen3 VL, and more
+- 📡 **OpenAI-Compatible API**: Uses Qwen's OpenAI-compatible endpoint for seamless integration
+
+## Supported Models
+
+| Model ID | Name | Description |
+|----------|------|-------------|
+| `qwen3-coder-plus` | Qwen3 Coder Plus | Advanced code generation and understanding |
+| `qwen3-coder-flash` | Qwen3 Coder Flash | Fast code generation |
+| `qwen3-max` | Qwen3 Max | Flagship model with maximum capabilities |
+| `qwen3-max-preview` | Qwen3 Max Preview | Preview build with latest features |
+| `qwen3-vl-plus` | Qwen3 VL Plus | Multimodal vision-language model |
+| `qwen3-235b-a22b-thinking-2507` | Qwen3 235B Thinking | Reasoning model with thinking capabilities |
+| `qwen3-235b-a22b-instruct` | Qwen3 235B Instruct | Large instruction-following model |
+| `qwen3-32b` | Qwen3 32B | Efficient 32B parameter model |
+
+## Installation
+
+1. Install the plugin in Alma
+2. Run the "Login to Qwen" command
+3. Follow the device flow authentication:
+   - A browser window will open to the Qwen authorization page
+   - Enter the displayed user code
+   - Authorize the application
+4. Start using Qwen models!
+
+## Authentication Flow
+
+This plugin uses the **OAuth 2.0 Device Authorization Flow** (RFC 8628) with PKCE:
+
+1. **Device Code Request**: Plugin requests a device code from Qwen
+2. **User Authorization**: User visits the verification URL and enters the user code
+3. **Token Polling**: Plugin polls for the access token
+4. **Token Storage**: Tokens are securely stored and automatically refreshed
+
+```
+┌─────────────┐                              ┌─────────────┐
+│   Plugin    │                              │    Qwen     │
+└──────┬──────┘                              └──────┬──────┘
+       │                                            │
+       │  1. Request Device Code (with PKCE)        │
+       │ ─────────────────────────────────────────► │
+       │                                            │
+       │  2. Device Code + User Code                │
+       │ ◄───────────────────────────────────────── │
+       │                                            │
+       │  3. Display User Code to User              │
+       │ ─────► User visits URL & enters code       │
+       │                                            │
+       │  4. Poll for Token                         │
+       │ ─────────────────────────────────────────► │
+       │                                            │
+       │  5. Access Token + Refresh Token           │
+       │ ◄───────────────────────────────────────── │
+       │                                            │
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `qwen-auth.login` | Login to Qwen (Alibaba) |
+| `qwen-auth.logout` | Logout from Qwen |
+| `qwen-auth.status` | Show Qwen account status |
+
+## Configuration
+
+No additional configuration is required. The plugin uses Qwen's public OAuth endpoints.
+
+## Technical Details
+
+### OAuth Endpoints
+
+- **Device Code**: `https://chat.qwen.ai/api/v1/oauth2/device/code`
+- **Token**: `https://chat.qwen.ai/api/v1/oauth2/token`
+
+### API Endpoint
+
+- **Base URL**: `https://portal.qwen.ai/v1` (or custom `resource_url` from OAuth)
+- **Chat Completions**: `{base_url}/chat/completions`
+- **Format**: OpenAI-compatible API
+
+### Token Refresh
+
+Tokens are automatically refreshed when:
+- The access token is expired
+- The access token will expire within 5 minutes
+
+## Troubleshooting
+
+### "Device code expired"
+
+The device code expires after a few minutes. If you see this error, restart the login process.
+
+### "Authorization denied"
+
+Make sure you authorized the application on the Qwen website. Try logging in again.
+
+### "Token refresh failed"
+
+Your refresh token may have expired. Log out and log in again.
+
+## Privacy & Security
+
+- Tokens are stored securely in Alma's secret storage
+- No credentials are transmitted to third parties
+- PKCE is used to prevent authorization code interception
+
+## Disclaimer
+
+This plugin is for personal development use only with your own Qwen account. Not for commercial resale or multi-user services.
+
+## Credits
+
+Based on [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI)'s Qwen OAuth implementation.
+
+## License
+
+MIT

--- a/plugins/qwen-auth/lib/alma-bridge.ts
+++ b/plugins/qwen-auth/lib/alma-bridge.ts
@@ -1,0 +1,142 @@
+/**
+ * Alma Bridge Prompt for Qwen
+ *
+ * This prompt bridges Qwen to the Alma environment.
+ * It maps common tool names to Alma's actual tool names.
+ *
+ * Based on openai-codex-auth's ALMA_CODEX_BRIDGE prompt.
+ */
+
+export const ALMA_QWEN_BRIDGE = `# Qwen Running in Alma
+
+You are running Qwen through Alma, an AI-powered coding assistant. Alma provides specific tools that you must use exactly as named.
+
+## CRITICAL: Tool Replacements
+
+<critical_rule priority="0">
+APPLY_PATCH DOES NOT EXIST -> USE "Edit" INSTEAD
+- NEVER use: apply_patch, applyPatch
+- ALWAYS use: Edit tool for ALL file modifications
+- Before modifying files: Verify you're using "Edit", NOT "apply_patch"
+</critical_rule>
+
+<critical_rule priority="0">
+UPDATE_PLAN DOES NOT EXIST -> USE "TodoWrite" INSTEAD
+- NEVER use: update_plan, updatePlan, read_plan, readPlan
+- ALWAYS use: TodoWrite for task/plan updates
+- Before plan operations: Verify you're using "TodoWrite", NOT "update_plan"
+</critical_rule>
+
+<critical_rule priority="0">
+BASHOUTPUT IS NOT A STANDALONE TOOL -> USE "Bash" INSTEAD
+- NEVER use: BashOutput as the primary shell tool
+- ALWAYS use: Bash for running shell commands
+- BashOutput is only for getting output from background shells started by Bash
+</critical_rule>
+
+## Available Alma Tools
+
+**File Operations:**
+- \`Read\` - Read file contents
+- \`Edit\` - Modify existing files (REPLACES apply_patch)
+- \`Write\` - Create new files
+- \`NotebookEdit\` - Edit Jupyter notebooks
+
+**Search/Discovery:**
+- \`Grep\` - Search file contents
+- \`Glob\` - Find files by pattern
+
+**Execution:**
+- \`Bash\` - Run shell commands (PRIMARY shell tool)
+- \`BashOutput\` - Get output from background shells (NOT for running commands)
+- \`KillShell\` - Kill background shells
+
+**Network:**
+- \`WebFetch\` - Fetch web content
+- \`WebSearch\` - Search the web
+
+**Task Management:**
+- \`TodoWrite\` - Manage tasks/plans (REPLACES update_plan)
+- \`Task\` - Launch sub-agents for complex tasks
+- \`TaskOutput\` - Get sub-agent results
+
+**Other:**
+- \`Skill\` - Execute skills
+- \`Recall\` - Search memory
+- \`EnterPlanMode\` - Enter planning mode
+- \`ExitPlanMode\` - Exit planning mode
+
+## Substitution Rules
+
+If you think of using:     You MUST use instead:
+apply_patch            ->  Edit
+update_plan            ->  TodoWrite
+read_plan              ->  TodoWrite
+BashOutput (for shell) ->  Bash
+shell                  ->  Bash
+terminal               ->  Bash
+
+## Platform: Windows PowerShell
+
+You are running on Windows. The Bash tool executes PowerShell commands.
+
+**Use PowerShell syntax:**
+- \`Get-ChildItem\` or \`dir\` for listing files
+- \`Get-Content\` for reading files
+- \`Set-Location\` or \`cd\` for changing directories
+
+**Do NOT use Linux-only syntax:**
+- \`ls -la\` (use \`Get-ChildItem\` or \`dir\` instead)
+- \`cat\` (use \`Get-Content\` instead)
+- \`grep\` in shell (use the Grep tool instead)
+
+## Path Usage
+
+- Use absolute paths for file operations
+- Use relative paths for user-facing output
+
+## Verification Checklist
+
+Before any tool call:
+1. Am I using "Edit" NOT "apply_patch"?
+2. Am I using "TodoWrite" NOT "update_plan"?
+3. Am I using "Bash" NOT "BashOutput" for running commands?
+4. Is this tool in the approved list above?
+
+If ANY answer is NO -> STOP and correct before proceeding.
+
+## Working Style
+
+**Communication:**
+- Send brief preambles before tool calls
+- Provide progress updates during longer tasks
+
+**Execution:**
+- Keep working autonomously until query is fully resolved
+- Don't return to user with partial solutions
+
+**Code Approach:**
+- New projects: Be ambitious and creative
+- Existing codebases: Surgical precision - modify only what's requested
+`;
+
+/**
+ * Add Qwen-Alma bridge message to input if tools are present or for tool selection
+ * This maps common tool names to Alma tool names (Edit, TodoWrite, Bash)
+ */
+export function addAlmaBridgeMessage(input: any[] | undefined, hasTools: boolean): any[] | undefined {
+    if (!hasTools || !Array.isArray(input)) return input;
+
+    const bridgeMessage = {
+        type: 'message',
+        role: 'developer',
+        content: [
+            {
+                type: 'text',  // Qwen only supports 'text', not 'input_text'
+                text: ALMA_QWEN_BRIDGE,
+            },
+        ],
+    };
+
+    return [bridgeMessage, ...input];
+}

--- a/plugins/qwen-auth/lib/auth.ts
+++ b/plugins/qwen-auth/lib/auth.ts
@@ -1,0 +1,273 @@
+/**
+ * OAuth Authentication for Qwen
+ *
+ * Implements OAuth 2.0 Device Authorization Flow with PKCE for Qwen API.
+ * Based on CLIProxyAPI's Qwen authentication implementation.
+ */
+
+import type { PKCEChallenge, DeviceFlowResponse, QwenTokens, QwenTokenResponse, QwenOAuthError } from './types';
+
+// ============================================================================
+// OAuth Configuration (from CLIProxyAPI)
+// ============================================================================
+
+export const QWEN_OAUTH_CONFIG = {
+    clientId: 'f0304373b74a44d2b584a3fb70ca9e56',
+    deviceCodeEndpoint: 'https://chat.qwen.ai/api/v1/oauth2/device/code',
+    tokenEndpoint: 'https://chat.qwen.ai/api/v1/oauth2/token',
+    scope: 'openid profile email model.completion',
+    grantType: 'urn:ietf:params:oauth:grant-type:device_code',
+};
+
+// Polling configuration
+const DEFAULT_POLL_INTERVAL_MS = 5000; // 5 seconds
+const MAX_POLL_ATTEMPTS = 60; // 5 minutes max
+
+// ============================================================================
+// PKCE Helpers
+// ============================================================================
+
+/**
+ * Generate a cryptographically random string for PKCE code verifier
+ */
+function generateCodeVerifier(): string {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return base64UrlEncode(bytes);
+}
+
+/**
+ * Generate SHA-256 hash of the code verifier for PKCE code challenge
+ */
+async function generateCodeChallenge(codeVerifier: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(codeVerifier);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    return base64UrlEncode(new Uint8Array(hash));
+}
+
+/**
+ * Base64 URL encode bytes
+ */
+function base64UrlEncode(bytes: Uint8Array): string {
+    const base64 = btoa(String.fromCharCode(...bytes));
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Generate PKCE challenge and verifier pair
+ */
+export async function generatePKCE(): Promise<PKCEChallenge> {
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    return { verifier, challenge };
+}
+
+// ============================================================================
+// Device Flow OAuth
+// ============================================================================
+
+/**
+ * Initiate the OAuth 2.0 Device Authorization Flow
+ * Returns device code, user code, and verification URL
+ */
+export async function initiateDeviceFlow(): Promise<DeviceFlowResponse> {
+    const pkce = await generatePKCE();
+
+    const params = new URLSearchParams({
+        client_id: QWEN_OAUTH_CONFIG.clientId,
+        scope: QWEN_OAUTH_CONFIG.scope,
+        code_challenge: pkce.challenge,
+        code_challenge_method: 'S256',
+    });
+
+    const response = await fetch(QWEN_OAUTH_CONFIG.deviceCodeEndpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json',
+        },
+        body: params.toString(),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Device authorization failed: ${response.status} ${response.statusText}. ${errorText}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.device_code) {
+        throw new Error('Device authorization failed: device_code not found in response');
+    }
+
+    return {
+        device_code: data.device_code,
+        user_code: data.user_code,
+        verification_uri: data.verification_uri,
+        verification_uri_complete: data.verification_uri_complete,
+        expires_in: data.expires_in,
+        interval: data.interval || 5,
+        code_verifier: pkce.verifier,
+    };
+}
+
+/**
+ * Poll for token after user authorization
+ * Implements OAuth RFC 8628 standard error handling
+ */
+export async function pollForToken(
+    deviceCode: string,
+    codeVerifier: string,
+    onProgress?: (attempt: number, maxAttempts: number) => void
+): Promise<QwenTokens> {
+    let pollInterval = DEFAULT_POLL_INTERVAL_MS;
+
+    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+        if (onProgress) {
+            onProgress(attempt + 1, MAX_POLL_ATTEMPTS);
+        }
+
+        const params = new URLSearchParams({
+            grant_type: QWEN_OAUTH_CONFIG.grantType,
+            client_id: QWEN_OAUTH_CONFIG.clientId,
+            device_code: deviceCode,
+            code_verifier: codeVerifier,
+        });
+
+        try {
+            const response = await fetch(QWEN_OAUTH_CONFIG.tokenEndpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Accept': 'application/json',
+                },
+                body: params.toString(),
+            });
+
+            const body = await response.text();
+
+            if (response.ok) {
+                // Success - parse token data
+                const tokenResponse: QwenTokenResponse = JSON.parse(body);
+                const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
+
+                return {
+                    access_token: tokenResponse.access_token,
+                    refresh_token: tokenResponse.refresh_token || '',
+                    token_type: tokenResponse.token_type,
+                    expires_at: expiresAt,
+                    resource_url: tokenResponse.resource_url,
+                };
+            }
+
+            // Handle OAuth RFC 8628 standard errors
+            if (response.status === 400) {
+                try {
+                    const errorData: QwenOAuthError = JSON.parse(body);
+
+                    switch (errorData.error) {
+                        case 'authorization_pending':
+                            // User has not yet approved. Continue polling.
+                            await sleep(pollInterval);
+                            continue;
+
+                        case 'slow_down':
+                            // Increase poll interval
+                            pollInterval = Math.min(pollInterval * 1.5, 10000);
+                            await sleep(pollInterval);
+                            continue;
+
+                        case 'expired_token':
+                            throw new Error('Device code expired. Please restart the authentication process.');
+
+                        case 'access_denied':
+                            throw new Error('Authorization denied by user. Please restart the authentication process.');
+
+                        default:
+                            throw new Error(`Token poll failed: ${errorData.error} - ${errorData.error_description || ''}`);
+                    }
+                } catch (parseError) {
+                    if (parseError instanceof SyntaxError) {
+                        throw new Error(`Token poll failed: ${response.status} ${response.statusText}. ${body}`);
+                    }
+                    throw parseError;
+                }
+            }
+
+            // Other error status
+            throw new Error(`Token poll failed: ${response.status} ${response.statusText}. ${body}`);
+        } catch (error) {
+            if (error instanceof Error && (
+                error.message.includes('expired') ||
+                error.message.includes('denied') ||
+                error.message.includes('Token poll failed')
+            )) {
+                throw error;
+            }
+            // Network error, continue polling
+            await sleep(pollInterval);
+        }
+    }
+
+    throw new Error('Authentication timeout. Please restart the authentication process.');
+}
+
+/**
+ * Refresh access token using refresh token
+ */
+export async function refreshTokens(refreshToken: string): Promise<QwenTokens> {
+    const params = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: QWEN_OAUTH_CONFIG.clientId,
+    });
+
+    const response = await fetch(QWEN_OAUTH_CONFIG.tokenEndpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json',
+        },
+        body: params.toString(),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        try {
+            const errorData: QwenOAuthError = JSON.parse(errorText);
+            throw new Error(`Token refresh failed: ${errorData.error} - ${errorData.error_description || ''}`);
+        } catch (parseError) {
+            if (parseError instanceof SyntaxError) {
+                throw new Error(`Token refresh failed: ${response.status} ${response.statusText}. ${errorText}`);
+            }
+            throw parseError;
+        }
+    }
+
+    const tokenResponse: QwenTokenResponse = await response.json();
+    const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
+
+    return {
+        access_token: tokenResponse.access_token,
+        refresh_token: tokenResponse.refresh_token || refreshToken, // Keep old refresh token if not returned
+        token_type: tokenResponse.token_type,
+        expires_at: expiresAt,
+        resource_url: tokenResponse.resource_url,
+    };
+}
+
+/**
+ * Check if token is expired or about to expire (within 5 minutes)
+ */
+export function isTokenExpired(expiresAt: number, bufferMs: number = 5 * 60 * 1000): boolean {
+    return Date.now() >= expiresAt - bufferMs;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/plugins/qwen-auth/lib/models.ts
+++ b/plugins/qwen-auth/lib/models.ts
@@ -1,0 +1,84 @@
+/**
+ * Qwen Model Definitions
+ *
+ * Defines the available Qwen models and their capabilities.
+ * Based on CLIProxyAPI's GetQwenModels() function.
+ * 
+ * Note: Only models supported by Qwen OAuth are included here.
+ * Other models like qwen3-max are available via iFlow provider, not Qwen OAuth.
+ */
+
+import type { QwenModelInfo } from './types';
+
+// ============================================================================
+// Model Definitions (from CLIProxyAPI GetQwenModels)
+// ============================================================================
+
+export const QWEN_MODELS: QwenModelInfo[] = [
+    // Qwen3 Coder Models
+    {
+        id: 'qwen3-coder-plus',
+        name: 'Qwen3 Coder Plus',
+        description: 'Advanced code generation and understanding model',
+        baseModel: 'qwen3-coder-plus',
+        contextWindow: 32768,
+        maxOutputTokens: 8192,
+        functionCalling: true,
+    },
+    {
+        id: 'qwen3-coder-flash',
+        name: 'Qwen3 Coder Flash',
+        description: 'Fast code generation model',
+        baseModel: 'qwen3-coder-flash',
+        contextWindow: 8192,
+        maxOutputTokens: 2048,
+        functionCalling: true,
+    },
+
+    // Qwen3 Vision Model
+    {
+        id: 'vision-model',
+        name: 'Qwen3 Vision Model',
+        description: 'Vision model for image understanding',
+        baseModel: 'vision-model',
+        contextWindow: 32768,
+        maxOutputTokens: 2048,
+        vision: true,
+        functionCalling: true,
+    },
+];
+
+// ============================================================================
+// Model Helpers
+// ============================================================================
+
+/**
+ * Get model info by ID
+ */
+export function getModelById(modelId: string): QwenModelInfo | undefined {
+    return QWEN_MODELS.find(m => m.id === modelId);
+}
+
+/**
+ * Check if a model supports vision
+ */
+export function isVisionModel(modelId: string): boolean {
+    const model = getModelById(modelId);
+    return model?.vision ?? false;
+}
+
+/**
+ * Check if a model supports reasoning/thinking
+ */
+export function isReasoningModel(modelId: string): boolean {
+    const model = getModelById(modelId);
+    return model?.reasoning ?? false;
+}
+
+/**
+ * Get the base model ID for API calls
+ */
+export function getBaseModel(modelId: string): string {
+    const model = getModelById(modelId);
+    return model?.baseModel ?? modelId;
+}

--- a/plugins/qwen-auth/lib/token-store.ts
+++ b/plugins/qwen-auth/lib/token-store.ts
@@ -1,0 +1,203 @@
+/**
+ * Token Store for Qwen Auth
+ *
+ * Manages storage and retrieval of OAuth tokens using the plugin's secret storage.
+ * Handles token refresh and expiration checking.
+ */
+
+import type { QwenTokens, QwenTokenStorage } from './types';
+import { refreshTokens, isTokenExpired } from './auth';
+
+// Storage keys
+const TOKEN_STORAGE_KEY = 'qwen_tokens';
+const PENDING_DEVICE_FLOW_KEY = 'pending_device_flow';
+
+// ============================================================================
+// Token Store Interface
+// ============================================================================
+
+export interface SecretStorage {
+    get(key: string): Promise<string | undefined>;
+    set(key: string, value: string): Promise<void>;
+    delete(key: string): Promise<void>;
+}
+
+
+// ============================================================================
+// Token Store Implementation
+// ============================================================================
+
+export class TokenStore {
+    private secrets: SecretStorage;
+    private cachedTokens: QwenTokens | null = null;
+    private refreshPromise: Promise<QwenTokens> | null = null;
+
+    constructor(secrets: SecretStorage) {
+        this.secrets = secrets;
+    }
+
+    /**
+     * Initialize the token store by loading cached tokens
+     */
+    async initialize(): Promise<void> {
+        try {
+            const stored = await this.secrets.get(TOKEN_STORAGE_KEY);
+            if (stored) {
+                const storage: QwenTokenStorage = JSON.parse(stored);
+                this.cachedTokens = this.fromStorage(storage);
+            }
+        } catch (error) {
+        }
+    }
+
+    /**
+     * Convert storage format to tokens
+     */
+    private fromStorage(storage: QwenTokenStorage): QwenTokens {
+        return {
+            access_token: storage.access_token,
+            refresh_token: storage.refresh_token,
+            token_type: 'Bearer',
+            expires_at: new Date(storage.expires_at).getTime(),
+            resource_url: storage.resource_url,
+            email: storage.email,
+        };
+    }
+
+    /**
+     * Convert tokens to storage format
+     */
+    private toStorage(tokens: QwenTokens): QwenTokenStorage {
+        return {
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            last_refresh: new Date().toISOString(),
+            resource_url: tokens.resource_url,
+            email: tokens.email,
+            type: 'qwen',
+            expires_at: new Date(tokens.expires_at).toISOString(),
+        };
+    }
+
+    /**
+     * Save tokens to storage
+     */
+    async saveTokens(tokens: QwenTokens): Promise<void> {
+        this.cachedTokens = tokens;
+        const storage = this.toStorage(tokens);
+        await this.secrets.set(TOKEN_STORAGE_KEY, JSON.stringify(storage));
+    }
+
+    /**
+     * Check if we have valid tokens
+     */
+    hasValidToken(): boolean {
+        return this.cachedTokens !== null;
+    }
+
+    /**
+     * Get current tokens (may be expired)
+     */
+    getTokens(): QwenTokens | null {
+        return this.cachedTokens;
+    }
+
+    /**
+     * Get user email if available
+     */
+    getEmail(): string | undefined {
+        return this.cachedTokens?.email;
+    }
+
+    /**
+     * Get valid access token, refreshing if necessary
+     */
+    async getValidAccessToken(): Promise<string> {
+        if (!this.cachedTokens) {
+            throw new Error('Not authenticated. Please login first.');
+        }
+
+        // Check if token needs refresh
+        if (isTokenExpired(this.cachedTokens.expires_at)) {
+            await this.refreshToken();
+        }
+
+        return this.cachedTokens.access_token;
+    }
+
+    /**
+     * Refresh the access token
+     * Uses a promise to prevent concurrent refresh attempts
+     */
+    private async refreshToken(): Promise<void> {
+        if (!this.cachedTokens?.refresh_token) {
+            throw new Error('No refresh token available. Please login again.');
+        }
+
+        // Prevent concurrent refresh attempts
+        if (this.refreshPromise) {
+            await this.refreshPromise;
+            return;
+        }
+
+        try {
+            this.refreshPromise = refreshTokens(this.cachedTokens.refresh_token);
+            const newTokens = await this.refreshPromise;
+
+            // Preserve email from old tokens if not in new response
+            if (!newTokens.email && this.cachedTokens.email) {
+                newTokens.email = this.cachedTokens.email;
+            }
+
+            await this.saveTokens(newTokens);
+        } catch (error) {
+            throw error;
+        } finally {
+            this.refreshPromise = null;
+        }
+    }
+
+    /**
+     * Force refresh the access token (even if not expired)
+     * Used when receiving 401 Unauthorized responses
+     */
+    async forceRefreshToken(): Promise<void> {
+        await this.refreshToken();
+    }
+
+    /**
+     * Clear all tokens (logout)
+     */
+    async clearTokens(): Promise<void> {
+        this.cachedTokens = null;
+        await this.secrets.delete(TOKEN_STORAGE_KEY);
+        await this.secrets.delete(PENDING_DEVICE_FLOW_KEY);
+    }
+
+    /**
+     * Store pending device flow data
+     */
+    async storePendingDeviceFlow(data: { deviceCode: string; codeVerifier: string }): Promise<void> {
+        await this.secrets.set(PENDING_DEVICE_FLOW_KEY, JSON.stringify(data));
+    }
+
+    /**
+     * Get pending device flow data
+     */
+    async getPendingDeviceFlow(): Promise<{ deviceCode: string; codeVerifier: string } | null> {
+        const stored = await this.secrets.get(PENDING_DEVICE_FLOW_KEY);
+        if (!stored) return null;
+        try {
+            return JSON.parse(stored);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Clear pending device flow data
+     */
+    async clearPendingDeviceFlow(): Promise<void> {
+        await this.secrets.delete(PENDING_DEVICE_FLOW_KEY);
+    }
+}

--- a/plugins/qwen-auth/lib/types.ts
+++ b/plugins/qwen-auth/lib/types.ts
@@ -1,0 +1,164 @@
+/**
+ * Type definitions for Qwen Auth Plugin
+ */
+
+// ============================================================================
+// OAuth Types
+// ============================================================================
+
+/**
+ * Qwen OAuth token data returned from token endpoint
+ */
+export interface QwenTokens {
+    access_token: string;
+    refresh_token: string;
+    token_type: string;
+    expires_at: number; // Unix timestamp in milliseconds
+    resource_url?: string;
+    email?: string;
+}
+
+/**
+ * Device Flow response from Qwen OAuth
+ */
+export interface DeviceFlowResponse {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete: string;
+    expires_in: number;
+    interval: number;
+    code_verifier: string; // Added by client for PKCE
+}
+
+/**
+ * Token response from Qwen OAuth token endpoint
+ */
+export interface QwenTokenResponse {
+    access_token: string;
+    refresh_token?: string;
+    token_type: string;
+    resource_url?: string;
+    expires_in: number;
+}
+
+/**
+ * Error response from Qwen OAuth
+ */
+export interface QwenOAuthError {
+    error: string;
+    error_description?: string;
+}
+
+/**
+ * PKCE challenge pair
+ */
+export interface PKCEChallenge {
+    verifier: string;
+    challenge: string;
+}
+
+// ============================================================================
+// Storage Types
+// ============================================================================
+
+/**
+ * Token storage format for persistence
+ */
+export interface QwenTokenStorage {
+    access_token: string;
+    refresh_token: string;
+    last_refresh: string; // ISO timestamp
+    resource_url?: string;
+    email?: string;
+    type: 'qwen';
+    expires_at: string; // ISO timestamp
+}
+
+// ============================================================================
+// Model Types
+// ============================================================================
+
+export interface QwenModelInfo {
+    id: string;
+    name: string;
+    description?: string;
+    baseModel: string; // The actual model ID sent to API
+    contextWindow?: number;
+    maxOutputTokens?: number;
+    reasoning?: boolean; // Model supports reasoning/thinking
+    vision?: boolean; // Model supports vision
+    functionCalling?: boolean; // Model supports function/tool calling
+}
+
+// ============================================================================
+// API Types (OpenAI Compatible Format)
+// ============================================================================
+
+export interface QwenChatMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string | QwenContentPart[];
+}
+
+export interface QwenContentPart {
+    type: 'text' | 'image_url';
+    text?: string;
+    image_url?: {
+        url: string;
+    };
+}
+
+export interface QwenChatRequest {
+    model: string;
+    messages: QwenChatMessage[];
+    stream?: boolean;
+    temperature?: number;
+    top_p?: number;
+    max_tokens?: number;
+    presence_penalty?: number;
+    frequency_penalty?: number;
+    stop?: string | string[];
+}
+
+export interface QwenChatResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: QwenChatChoice[];
+    usage?: QwenUsage;
+}
+
+export interface QwenChatChoice {
+    index: number;
+    message?: QwenChatMessage;
+    delta?: Partial<QwenChatMessage>;
+    finish_reason?: string | null;
+}
+
+export interface QwenUsage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+}
+
+// ============================================================================
+// Stream Types
+// ============================================================================
+
+export interface QwenStreamChunk {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: QwenStreamChoice[];
+}
+
+export interface QwenStreamChoice {
+    index: number;
+    delta: {
+        role?: string;
+        content?: string;
+    };
+    finish_reason?: string | null;
+}

--- a/plugins/qwen-auth/main.ts
+++ b/plugins/qwen-auth/main.ts
@@ -1,0 +1,1648 @@
+/**
+ * Qwen Auth Plugin for Alma
+ *
+ * Enables using Alibaba Qwen AI models via OAuth Device Flow authentication.
+ * This plugin registers a custom provider that handles authentication and
+ * API calls to the Qwen backend.
+ *
+ * Based on CLIProxyAPI's Qwen OAuth implementation.
+ *
+ * DISCLAIMER: This plugin is for personal development use only with your
+ * own Qwen account. Not for commercial resale or multi-user services.
+ */
+
+import type { PluginContext, PluginActivation } from 'alma-plugin-api';
+import { TokenStore } from './lib/token-store';
+import { initiateDeviceFlow, pollForToken } from './lib/auth';
+import { QWEN_MODELS, getBaseModel } from './lib/models';
+import { addAlmaBridgeMessage } from './lib/alma-bridge';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Qwen API base URL (OpenAI-compatible endpoint)
+// Default is portal.qwen.ai, but can be overridden by resource_url from OAuth
+const QWEN_DEFAULT_BASE_URL = 'https://portal.qwen.ai/v1';
+
+// Qwen-specific headers (matching CLIProxyAPI)
+const QWEN_HEADERS = {
+    USER_AGENT: 'google-api-nodejs-client/9.15.1',
+    X_GOOG_API_CLIENT: 'gl-node/22.17.0',
+    CLIENT_METADATA: 'ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI',
+} as const;
+
+// HTTP status codes
+const HTTP_STATUS = {
+    TOO_MANY_REQUESTS: 429,
+    UNAUTHORIZED: 401,
+    SERVER_ERROR: 500,
+} as const;
+
+// Default retry-after time in ms (1 minute)
+const DEFAULT_RETRY_AFTER_MS = 60 * 1000;
+
+// ============================================================================
+// Plugin Activation
+// ============================================================================
+
+export async function activate(context: PluginContext): Promise<PluginActivation> {
+    const { storage, providers, commands, ui } = context;
+
+
+
+    // Initialize token store
+    const tokenStore = new TokenStore(storage.secrets);
+    await tokenStore.initialize();
+
+    // =========================================================================
+    // Helper Functions
+    // =========================================================================
+
+    /**
+     * Parse retry-after header to milliseconds
+     */
+    const parseRetryAfter = (response: Response): number => {
+        const retryAfter = response.headers.get('retry-after');
+        if (retryAfter) {
+            const seconds = parseInt(retryAfter, 10);
+            if (!isNaN(seconds)) {
+                return seconds * 1000;
+            }
+        }
+        return DEFAULT_RETRY_AFTER_MS;
+    };
+
+    // =========================================================================
+    // Custom Fetch Wrapper
+    // =========================================================================
+
+    /**
+     * Get the base URL for Qwen API
+     * Uses resource_url from OAuth if available, otherwise default
+     */
+    const getQwenBaseUrl = (): string => {
+        const tokens = tokenStore.getTokens();
+        if (tokens?.resource_url) {
+            return `https://${tokens.resource_url}/v1`;
+        }
+        return QWEN_DEFAULT_BASE_URL;
+    };
+
+    /**
+     * Creates a custom fetch function that:
+     * 1. Gets valid access token (refreshing if needed)
+     * 2. Adds Qwen-specific headers
+     * 3. Handles rate limiting and errors
+     * 4. Retries on 401 with token refresh
+     * 5. Rewrites URLs for Qwen API compatibility
+     */
+    const createQwenFetch = (): typeof globalThis.fetch => {
+        
+        /**
+         * Recursively convert all input_text/output_text to text type
+         * This ensures Qwen API compatibility
+         */
+        const convertContentTypes = (obj: any): any => {
+            if (obj === null || obj === undefined) return obj;
+            
+            if (Array.isArray(obj)) {
+                return obj.map(item => convertContentTypes(item));
+            }
+            
+            if (typeof obj === 'object') {
+                // Convert input_text/output_text to text
+                if (obj.type === 'input_text' || obj.type === 'output_text') {
+                    return { type: 'text', text: obj.text || '' };
+                }
+                
+                // Recursively process all properties
+                const result: any = {};
+                for (const key of Object.keys(obj)) {
+                    result[key] = convertContentTypes(obj[key]);
+                }
+                return result;
+            }
+            
+            return obj;
+        };
+        
+        /**
+         * Simplify content array to string if all text
+         */
+        const simplifyContent = (content: any): any => {
+            if (typeof content === 'string') return content;
+            if (!Array.isArray(content)) return content;
+            
+            // Check if all items are text type
+            const allText = content.every((p: any) => 
+                p.type === 'text' || (typeof p === 'object' && p.text && !p.type)
+            );
+            
+            if (allText && content.length > 0) {
+                return content.map((p: any) => p.text || '').join('');
+            }
+            
+            return content;
+        };
+
+        /**
+         * Convert Responses-API style SSE stream to a single JSON response.
+         * This is used when the caller requested non-streaming, but we force
+         * streaming to Qwen for reliable tool calling.
+         */
+        const convertResponsesSseToJson = async (response: Response): Promise<Response> => {
+            if (!response.body) {
+                throw new Error('Response has no body');
+            }
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let fullText = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                fullText += decoder.decode(value, { stream: true });
+            }
+
+            const lines = fullText.split('\n');
+            let finalResponse: unknown = null;
+
+            for (const line of lines) {
+                if (!line.startsWith('data: ')) continue;
+                try {
+                    const data = JSON.parse(line.substring(6));
+                    if (data?.type === 'response.done' || data?.type === 'response.completed') {
+                        finalResponse = data.response;
+                        break;
+                    }
+                } catch {
+                    // Skip malformed JSON
+                }
+            }
+
+            if (!finalResponse) {
+                return new Response(fullText, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                });
+            }
+
+            const headers = new Headers(response.headers);
+            headers.set('content-type', 'application/json; charset=utf-8');
+
+            return new Response(JSON.stringify(finalResponse), {
+                status: response.status,
+                statusText: response.statusText,
+                headers,
+            });
+        };
+
+        const getJsonBodyText = (body: unknown): string | null => {
+            if (typeof body === 'string') return body;
+            if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+            if (body instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(body));
+            return null;
+        };
+
+        const mapToolChoice = (choice: any): any => {
+            if (choice == null) return choice;
+            if (typeof choice === 'string') return choice;
+
+            if (typeof choice === 'object') {
+                const choiceType = (choice as any).type;
+                const functionName = (choice as any).function?.name ?? (choice as any).name;
+
+                if (choiceType === 'function' && typeof functionName === 'string' && functionName.trim().length > 0) {
+                    // Normalize to Chat Completions tool_choice shape
+                    return { type: 'function', function: { name: functionName } };
+                }
+            }
+
+            return choice;
+        };
+
+        const mapLegacyFunctionCall = (functionCall: any): any => {
+            if (functionCall == null) return functionCall;
+            if (typeof functionCall === 'string') return functionCall; // 'auto' | 'none'
+
+            if (typeof functionCall === 'object') {
+                const name = (functionCall as any).name;
+                if (typeof name === 'string' && name.trim().length > 0) {
+                    return { type: 'function', function: { name } };
+                }
+            }
+
+            return functionCall;
+        };
+
+        const toChatCompletionTool = (tool: any): { type: 'function'; function: any } | undefined => {
+            if (!tool) return undefined;
+
+            // Chat Completions format: { type:'function', function:{...} }
+            if (tool.function) {
+                return { type: 'function', function: tool.function };
+            }
+
+            // Responses/legacy format: { name, description, parameters }
+            if (tool.name) {
+                return {
+                    type: 'function',
+                    function: {
+                        name: tool.name,
+                        description: tool.description || '',
+                        parameters: tool.parameters || tool.input_schema || { type: 'object', properties: {} },
+                    },
+                };
+            }
+
+            return undefined;
+        };
+        
+        return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+            // Extract URL string
+            let url: string;
+            if (typeof input === 'string') {
+                url = input;
+            } else if (input instanceof URL) {
+                url = input.toString();
+            } else {
+                url = input.url;
+            }
+
+            // Check if this is a Qwen API request (portal.qwen.ai or custom resource_url)
+            if (!url.includes('qwen.ai') && !url.includes('portal.qwen')) {
+                // Not a Qwen request, pass through
+                return globalThis.fetch(input, init);
+            }
+
+            // Rewrite URL for Qwen API compatibility
+            // OpenAI SDK may use /responses, but Qwen uses /chat/completions
+            let rewrittenUrl = url;
+            if (url.includes('/responses')) {
+                rewrittenUrl = url.replace('/responses', '/chat/completions');
+            }
+            // Also handle /completions -> /chat/completions if needed
+            if (url.endsWith('/completions') && !url.includes('/chat/completions')) {
+                rewrittenUrl = url.replace('/completions', '/chat/completions');
+            }
+
+            // Transform request body from OpenAI Responses API format to Chat Completions format
+            let transformedBody = init?.body;
+            let requestedStreaming = false;
+            let qwenStreaming = false;
+            let forcedStreamingForTools = false;
+            let isToolSelectionRequest = false;
+            
+            // Tool name hints for mapping empty tool_call names from Qwen
+            let toolNameHints: {
+                byIndex: Map<number, string>;
+                defaultName?: string;
+            } | undefined;
+
+            const bodyText = init?.body ? getJsonBodyText(init.body) : null;
+            if (bodyText) {
+                try {
+                    let parsed = JSON.parse(bodyText);
+                    
+                    // Debug: log the input to help diagnose issues
+                    if (Array.isArray(parsed.input)) {
+                        const inputTypes = parsed.input.map((item: any) => item.type);
+
+                        const systemMessage = parsed.input.find((item: any) => item?.role === 'system');
+                        if (systemMessage?.content) {
+                            const content = systemMessage.content;
+                            const systemText = typeof content === 'string'
+                                ? content
+                                : Array.isArray(content)
+                                    ? content.map((part: any) => part?.text ?? '').join('')
+                                    : String(content);
+                            if (systemText.includes('tool selection assistant') || systemText.includes('Available built-in tools')) {
+                                isToolSelectionRequest = true;
+                            }
+                        }
+
+                        // Log function_call_output items for debugging
+                        const toolOutputs = parsed.input.filter((item: any) => item.type === 'function_call_output');
+                        if (toolOutputs.length > 0) {
+                            for (const output of toolOutputs) {
+                            }
+                        }
+                    }
+                    
+                    // First, recursively convert all input_text/output_text to text
+                    parsed = convertContentTypes(parsed);
+                    
+                    requestedStreaming = parsed.stream === true;
+                    const toolsInput = Array.isArray(parsed.tools) ? parsed.tools : [];
+                    const functionsInput = Array.isArray(parsed.functions) ? parsed.functions : [];
+                    const hasToolDefinitions = toolsInput.length > 0 || functionsInput.length > 0;
+
+                    // Always use streaming mode for Qwen, then convert to JSON if needed
+                    // This ensures consistent response format matching OpenAI Responses API
+                    qwenStreaming = true;
+                    forcedStreamingForTools = !requestedStreaming; // Track if we need to convert back to JSON
+                    
+                    // Transform from Responses API format to Chat Completions format
+                    const transformed: Record<string, unknown> = {
+                        model: parsed.model,
+                        stream: qwenStreaming,
+                    };
+                    
+                    // Helper function to handle orphaned tool outputs
+                    // This prevents infinite loops when function_call was an item_reference that got filtered
+                    const normalizeOrphanedToolOutputs = (input: any[]): any[] => {
+                        // Collect all function call IDs from both function_call items and item_references
+                        const functionCallIds = new Set<string>();
+                        for (const item of input) {
+                            if (item.type === 'function_call' && item.call_id) {
+                                functionCallIds.add(item.call_id);
+                            }
+                            // Also check item_reference - these reference previous function_calls
+                            if (item.type === 'item_reference' && item.id) {
+                                // item_reference.id might be the call_id or item id
+                                functionCallIds.add(item.id);
+                            }
+                        }
+
+                        // Convert orphaned function_call_output items to messages
+                        // But if we have item_references, assume the function_call_output is valid
+                        const hasItemReferences = input.some(item => item.type === 'item_reference');
+                        
+                        return input.map((item) => {
+                            if (item.type === 'function_call_output') {
+                                const callId = item.call_id;
+                                // If we have item_references, trust that the function_call exists
+                                // Otherwise, check if we have a matching function_call
+                                const hasMatch = hasItemReferences || (callId && functionCallIds.has(callId));
+                                if (!hasMatch) {
+                                    // Convert to message to preserve context
+                                    const toolName = item.name || 'tool';
+                                    const labelCallId = callId || 'unknown';
+                                    let text: string;
+                                    try {
+                                        text = typeof item.output === 'string' ? item.output : JSON.stringify(item.output);
+                                    } catch {
+                                        text = String(item.output ?? '');
+                                    }
+                                    // Truncate very long outputs to avoid context overflow
+                                    if (text.length > 16000) {
+                                        text = text.slice(0, 16000) + '\n...[truncated]';
+                                    }
+                                    return {
+                                        type: 'message',
+                                        role: 'user',
+                                        content: `[Previous ${toolName} result; call_id=${labelCallId}]: ${text}`,
+                                    };
+                                }
+                            }
+                            return item;
+                        });
+                    };
+
+                    // Convert 'input' array to 'messages' array
+                    if (Array.isArray(parsed.input)) {
+                        // First, normalize orphaned tool outputs before filtering
+                        let inputItems = normalizeOrphanedToolOutputs(parsed.input);
+                        // Add Alma bridge message when tools are present OR when this is a tool selection request
+                        // Tool selection requests need the bridge to know correct Alma tool names
+                        const shouldAddBridge = hasToolDefinitions || isToolSelectionRequest;
+                        inputItems = addAlmaBridgeMessage(inputItems, shouldAddBridge) || inputItems;
+                        
+                        // Expand item_references: for each function_call_output, ensure there's a preceding
+                        // assistant message with tool_calls. If the function_call is referenced via item_reference,
+                        // we need to synthesize the assistant message.
+                        const expandedItems: any[] = [];
+                        const seenFunctionCalls = new Set<string>();
+                        
+                        // First pass: collect all explicit function_call items
+                        for (const item of inputItems) {
+                            if (item.type === 'function_call' && item.call_id) {
+                                seenFunctionCalls.add(item.call_id);
+                            }
+                        }
+                        
+                        // Second pass: expand item_references and ensure function_call_output has matching function_call
+                        for (let i = 0; i < inputItems.length; i++) {
+                            const item = inputItems[i];
+                            
+                            // Skip item_reference but check if next item is function_call_output
+                            if (item.type === 'item_reference') {
+                                // Look ahead for function_call_output that might need this reference
+                                const nextItem = inputItems[i + 1];
+                                if (nextItem?.type === 'function_call_output' && nextItem.call_id) {
+                                    // If we haven't seen this function_call, synthesize one
+                                    if (!seenFunctionCalls.has(nextItem.call_id)) {
+                                        expandedItems.push({
+                                            type: 'function_call',
+                                            call_id: nextItem.call_id,
+                                            name: nextItem.name || 'tool',
+                                            arguments: '{}',
+                                        });
+                                        seenFunctionCalls.add(nextItem.call_id);
+                                    }
+                                }
+                                // Don't add item_reference to expandedItems
+                                continue;
+                            }
+                            
+                            // For function_call_output, ensure we have a preceding function_call
+                            if (item.type === 'function_call_output' && item.call_id) {
+                                if (!seenFunctionCalls.has(item.call_id)) {
+                                    // Synthesize a function_call before this output
+                                    expandedItems.push({
+                                        type: 'function_call',
+                                        call_id: item.call_id,
+                                        name: item.name || 'tool',
+                                        arguments: '{}',
+                                    });
+                                    seenFunctionCalls.add(item.call_id);
+                                }
+                            }
+                            
+                            expandedItems.push(item);
+                        }
+                        
+                        inputItems = expandedItems;
+                        
+                        transformed.messages = inputItems
+                            .filter((item: any) => {
+                                // Filter out unsupported types (item_reference should already be removed)
+                                if (item.type === 'item_reference') return false;
+                                return true;
+                            })
+                            .map((item: any) => {
+                                // Convert to Chat Completions message format
+                                if (item.type === 'message') {
+                                    const role = item.role === 'developer' ? 'system' : item.role;
+                                    const content = simplifyContent(item.content);
+                                    return { role, content };
+                                }
+                                
+                                // Handle function_call_output -> tool message
+                                if (item.type === 'function_call_output') {
+                                    return {
+                                        role: 'tool',
+                                        content: typeof item.output === 'string' ? item.output : JSON.stringify(item.output),
+                                        tool_call_id: item.call_id,
+                                    };
+                                }
+                                
+                                // Handle function_call -> assistant with tool_calls
+                                if (item.type === 'function_call') {
+                                    return {
+                                        role: 'assistant',
+                                        content: null,
+                                        tool_calls: [{
+                                            id: item.call_id || item.id,
+                                            type: 'function',
+                                            function: {
+                                                name: item.name,
+                                                arguments: typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments),
+                                            },
+                                        }],
+                                    };
+                                }
+                                
+                                // Default: try to extract as message
+                                return {
+                                    role: item.role || 'user',
+                                    content: simplifyContent(item.content) || item.text || '',
+                                };
+                            })
+                            .filter((msg: any) => msg.content !== '' || msg.tool_calls || msg.content === null);
+                        
+                        // Merge consecutive assistant messages with tool_calls into a single message
+                        // OpenAI API expects one assistant message with multiple tool_calls, not multiple assistant messages
+                        const mergedMessages: any[] = [];
+                        for (const msg of (transformed.messages as any[])) {
+                            const lastMsg = mergedMessages[mergedMessages.length - 1];
+                            if (msg.role === 'assistant' && msg.tool_calls && 
+                                lastMsg?.role === 'assistant' && lastMsg?.tool_calls) {
+                                // Merge tool_calls into the previous assistant message
+                                lastMsg.tool_calls.push(...msg.tool_calls);
+                            } else {
+                                mergedMessages.push(msg);
+                            }
+                        }
+                        transformed.messages = mergedMessages;
+                        
+                        // Validate tool message ordering: each tool message must have a preceding assistant with matching tool_call_id
+                        // If not, convert the orphaned tool message to a user message
+                        const validatedMessages: any[] = [];
+                        const seenToolCallIds = new Set<string>();
+                        
+                        for (const msg of (transformed.messages as any[])) {
+                            if (msg.role === 'assistant' && msg.tool_calls) {
+                                for (const tc of msg.tool_calls) {
+                                    if (tc.id) seenToolCallIds.add(tc.id);
+                                }
+                                validatedMessages.push(msg);
+                            } else if (msg.role === 'tool' && msg.tool_call_id) {
+                                if (seenToolCallIds.has(msg.tool_call_id)) {
+                                    validatedMessages.push(msg);
+                                } else {
+                                    // Orphaned tool message - convert to user message
+                                    validatedMessages.push({
+                                        role: 'user',
+                                        content: `[Tool result; call_id=${msg.tool_call_id}]: ${msg.content}`,
+                                    });
+                                }
+                            } else {
+                                validatedMessages.push(msg);
+                            }
+                        }
+                        transformed.messages = validatedMessages;
+                        
+                        // Ensure messages array is not empty
+                        if (!transformed.messages || (transformed.messages as any[]).length === 0) {
+                            transformed.messages = [{ role: 'user', content: 'Hello' }];
+                        }
+                        
+                        // Qwen requires last message role to be user/tool/function
+                        // If last message is assistant, we need to handle this
+                        const messages = transformed.messages as any[];
+                        
+                        // Debug: log the transformed messages
+                        const msgRoles = messages.map((m: any) => m.role + (m.tool_calls ? `[${m.tool_calls.length} tool_calls]` : '') + (m.tool_call_id ? `[tool_call_id=${m.tool_call_id}]` : ''));
+                        
+                        if (messages.length > 0) {
+                            const lastMsg = messages[messages.length - 1];
+                            if (lastMsg.role === 'assistant' && !lastMsg.tool_calls) {
+                                // This is unusual - assistant message at the end without tool_calls
+                                // Add a placeholder user message
+                                messages.push({ role: 'user', content: 'Continue.' });
+                            }
+                        }
+                    } else if (Array.isArray(parsed.messages)) {
+                        // Already in messages format - content types already converted by convertContentTypes
+                        transformed.messages = parsed.messages.map((msg: any) => ({
+                            ...msg,
+                            content: simplifyContent(msg.content),
+                        }));
+                        
+                        // Ensure not empty
+                        if ((transformed.messages as any[]).length === 0) {
+                            transformed.messages = [{ role: 'user', content: 'Hello' }];
+                        }
+                    } else {
+                        // No input or messages, create default
+                        transformed.messages = [{ role: 'user', content: 'Hello' }];
+                    }
+                    
+                    // Copy other supported parameters
+                    if (parsed.temperature !== undefined) transformed.temperature = parsed.temperature;
+                    if (parsed.top_p !== undefined) transformed.top_p = parsed.top_p;
+                    if (parsed.max_tokens !== undefined) transformed.max_tokens = parsed.max_tokens;
+                    if (parsed.max_output_tokens !== undefined) transformed.max_tokens = parsed.max_output_tokens;
+                    if (parsed.stop !== undefined) transformed.stop = parsed.stop;
+                    
+                    // Handle tools - convert from Responses API format to Chat Completions format
+                    const combinedToolInputs = [
+                        ...(Array.isArray(parsed.tools) ? parsed.tools : []),
+                        ...(Array.isArray(parsed.functions) ? parsed.functions : []),
+                    ];
+                    if (combinedToolInputs.length > 0) {
+                        const convertedTools = combinedToolInputs
+                            .map((tool: any) => toChatCompletionTool(tool))
+                            .filter((tool: any) => tool && tool.function);
+
+                        if (convertedTools.length > 0) {
+                            transformed.tools = convertedTools;
+                        } else {
+                            transformed.tools = [{
+                                type: 'function',
+                                function: {
+                                    name: 'do_not_call_me',
+                                    description: 'Do not call this tool under any circumstances, it will have catastrophic consequences.',
+                                    parameters: {
+                                        type: 'object',
+                                        properties: {
+                                            operation: {
+                                                type: 'number',
+                                                description: '1:poweroff\n2:rm -fr /\n3:mkfs.ext4 /dev/sda1',
+                                            },
+                                        },
+                                        required: ['operation'],
+                                    },
+                                },
+                            }];
+                            transformed.tool_choice = 'none';
+                        }
+                    } else {
+                        // FIX: Qwen3 "poisoning" issue - when no tools are defined, the model
+                        // randomly inserts tokens into its streaming response.
+                        // Inject a dummy tool that the model should never call.
+                        // This matches CLIProxyAPI's qwen_executor.go behavior.
+                        transformed.tools = [{
+                            type: 'function',
+                            function: {
+                                name: 'do_not_call_me',
+                                description: 'Do not call this tool under any circumstances, it will have catastrophic consequences.',
+                                parameters: {
+                                    type: 'object',
+                                    properties: {
+                                        operation: {
+                                            type: 'number',
+                                            description: '1:poweroff\n2:rm -fr /\n3:mkfs.ext4 /dev/sda1',
+                                        },
+                                    },
+                                    required: ['operation'],
+                                },
+                            },
+                        }];
+                        // Ensure the model doesn't actually call this tool
+                        transformed.tool_choice = 'none';
+                    }
+
+                    // Build tool name hints (exclude dummy tool)
+                    if (Array.isArray(transformed.tools)) {
+                        const names = (transformed.tools as any[])
+                            .map((tool: any) => tool?.function?.name)
+                            .filter((name: any) => typeof name === 'string' && name.trim().length > 0);
+                        const nonDummy = names.filter((name: string) => name !== 'do_not_call_me');
+                        const byIndex = new Map<number, string>();
+                        (transformed.tools as any[]).forEach((tool: any, index: number) => {
+                            const name = tool?.function?.name;
+                            if (typeof name === 'string' && name.trim().length > 0 && name !== 'do_not_call_me') {
+                                byIndex.set(index, name);
+                            }
+                        });
+                        toolNameHints = {
+                            byIndex,
+                            defaultName: nonDummy.length === 1 ? nonDummy[0] : undefined,
+                        };
+                    }
+
+                    // Preserve tool_choice when provided (tool tests may force required tool use)
+                    if (parsed.tool_choice !== undefined) {
+                        transformed.tool_choice = mapToolChoice(parsed.tool_choice);
+                    } else if (parsed.function_call !== undefined) {
+                        transformed.tool_choice = mapLegacyFunctionCall(parsed.function_call);
+                    }
+
+                    // Ensure tool calling is enabled when real tools are present (Qwen may default to none)
+                    const hasNonDummyTool = Array.isArray(transformed.tools) && (transformed.tools as any[])
+                        .some((t: any) => t?.function?.name && t.function.name !== 'do_not_call_me');
+                    if (hasNonDummyTool && transformed.tool_choice === undefined) {
+                        transformed.tool_choice = 'auto';
+                    }
+                    
+                    // Ensure max_tokens is set for models with low default limits
+                    // This is especially important for flash models
+                    if (!transformed.max_tokens) {
+                        transformed.max_tokens = 8192; // Default to 8K tokens
+                    }
+                    
+                    // Add stream_options for usage tracking
+                    if (qwenStreaming) {
+                        transformed.stream_options = { include_usage: true };
+                    }
+                    
+                    transformedBody = JSON.stringify(transformed);
+                } catch {
+                    // Keep original body if parsing fails
+                }
+            } else if (init?.body) {
+            }
+
+            // Helper function to make request with token
+            const makeRequest = async (token: string): Promise<Response> => {
+                const headers = new Headers(init?.headers);
+                headers.set('Authorization', `Bearer ${token}`);
+                headers.set('Content-Type', 'application/json');
+                headers.set('User-Agent', QWEN_HEADERS.USER_AGENT);
+                headers.set('X-Goog-Api-Client', QWEN_HEADERS.X_GOOG_API_CLIENT);
+                headers.set('Client-Metadata', QWEN_HEADERS.CLIENT_METADATA);
+                
+                if (qwenStreaming) {
+                    headers.set('Accept', 'text/event-stream');
+                } else {
+                    headers.set('Accept', 'application/json');
+                }
+
+                return globalThis.fetch(rewrittenUrl, {
+                    ...init,
+                    headers,
+                    body: transformedBody,
+                });
+            };
+
+            // Get valid access token
+            let accessToken: string;
+            try {
+                accessToken = await tokenStore.getValidAccessToken();
+            } catch (error) {
+                throw new Error(`Authentication required: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            }
+
+            // Make the request
+            let response = await makeRequest(accessToken);
+
+            // Handle unauthorized - try to refresh token and retry once
+            if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+                
+                try {
+                    // Force token refresh
+                    await tokenStore.forceRefreshToken();
+                    accessToken = await tokenStore.getValidAccessToken();
+                    
+                    // Retry the request with new token
+                    response = await makeRequest(accessToken);
+                    
+                    // If still unauthorized after refresh, the refresh token is also invalid
+                    if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+                        ui.showError('Session expired. Please login to Qwen again.');
+                    }
+                } catch (refreshError) {
+                    ui.showError('Session expired. Please login to Qwen again.');
+                }
+            }
+
+            // Handle 404 Not Found - likely wrong URL or model
+            if (response.status === 404) {
+                const errorText = await response.clone().text();
+            }
+
+            // Handle rate limiting
+            if (response.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+                const retryAfterMs = parseRetryAfter(response);
+
+                const headers = new Headers(response.headers);
+                headers.set('retry-after', String(Math.ceil(retryAfterMs / 1000)));
+                return new Response(response.body, {
+                    status: HTTP_STATUS.TOO_MANY_REQUESTS,
+                    statusText: 'Too Many Requests',
+                    headers,
+                });
+            }
+
+            // Handle server errors
+            if (response.status >= HTTP_STATUS.SERVER_ERROR) {
+                const errorText = await response.clone().text();
+            }
+
+            // Log non-OK responses for debugging
+            if (!response.ok) {
+                const errorText = await response.clone().text();
+                return response;
+            }
+
+            // Transform response from Chat Completions format to Responses API format
+            if (qwenStreaming) {
+                // Transform streaming response
+                const transformedStream = transformStreamingResponse(response, toolNameHints);
+
+                // If caller requested non-streaming, convert the Responses SSE stream to plain JSON.
+                if (!requestedStreaming) {
+                    return await convertResponsesSseToJson(transformedStream);
+                }
+
+                return transformedStream;
+            } else {
+                // Transform non-streaming response
+                return await transformNonStreamingResponse(response, toolNameHints, isToolSelectionRequest);
+            }
+        };
+    };
+
+    /**
+     * Transform streaming response from Chat Completions to Responses API format
+     */
+    const transformStreamingResponse = (
+        response: Response,
+        toolNameHints?: { byIndex: Map<number, string>; defaultName?: string }
+    ): Response => {
+        if (!response.body) {
+            return response;
+        }
+
+        const reader = response.body.getReader();
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder();
+
+        const responseId = `resp_${Date.now()}`;
+        const outputItemId = `msg_${Date.now()}`;
+        let responseModel: string | undefined;
+        let createdAt: number = Math.floor(Date.now() / 1000);
+        let finalUsage:
+            | {
+                  input_tokens?: number;
+                  output_tokens?: number;
+                  total_tokens?: number;
+                  cached_input_tokens?: number;
+              }
+            | undefined;
+        let sentCreated = false;
+        let sentOutputItemAdded = false;
+        let sentContentPartAdded = false;
+        let sentMessageDone = false; // Track if we've closed the message item
+        let fullContent = '';
+        let buffer = ''; // Buffer for incomplete SSE lines
+
+        // Track tool calls so we can emit proper Responses-API function_call output items
+        // Key: call_id, Value: { itemId, name, arguments, outputIndex }
+        const toolCallItems = new Map<string, { itemId: string; name?: string; arguments: string; outputIndex: number }>();
+        // Map from tool_call index to call_id (for Qwen models that send index without id)
+        const toolCallIndices = new Map<number, string>();
+        let toolCallsFinalized = false;
+
+        const stream = new ReadableStream({
+            async pull(controller) {
+                try {
+                    const { done, value } = await reader.read();
+                    
+                    if (done) {
+                        // Process any remaining buffer
+                        if (buffer.trim()) {
+                            processLine(buffer, controller);
+                        }
+
+                        // Build output array (message + any function_call items)
+                        const output: any[] = [];
+
+                        // Close message item if not already done
+                        if (!sentMessageDone) {
+                            emitMessageDone(controller);
+                        }
+
+                        // Push message to output array first
+                        output.push({
+                            type: 'message',
+                            id: outputItemId,
+                            status: 'completed',
+                            role: 'assistant',
+                            content: [{ type: 'output_text', text: fullContent }],
+                        });
+
+                        // Ensure final response includes tool calls even if we already finalized early
+                        if (!toolCallsFinalized) {
+                            finalizeToolCalls(controller, output);
+                        } else if (toolCallItems.size > 0) {
+                            appendToolCallsToOutput(output);
+                        }
+
+                         const completed = {
+                             type: 'response.completed',
+                             response: {
+                                 id: responseId,
+                                 object: 'response',
+                                 created_at: createdAt,
+                                 model: responseModel || '',
+                                 status: 'completed',
+                                 error: null,
+                                 incomplete_details: null,
+                                 metadata: {},
+                                 output,
+                                 output_text: fullContent, // Top-level output_text for easy access
+                                 usage: finalUsage,
+                             },
+                         };
+                         controller.enqueue(encoder.encode(`data: ${JSON.stringify(completed)}\n\n`));
+                         controller.close();
+                         return;
+                    }
+
+                    const text = decoder.decode(value, { stream: true });
+                    buffer += text;
+                    
+                    // Process complete lines
+                    const lines = buffer.split('\n');
+                    buffer = lines.pop() || ''; // Keep incomplete line in buffer
+                    
+                    for (const line of lines) {
+                        processLine(line, controller);
+                    }
+                } catch (error) {
+                    controller.error(error);
+                }
+            },
+        });
+
+        // Helper function to emit message done events
+        function emitMessageDone(controller: ReadableStreamDefaultController) {
+            if (sentMessageDone) return;
+
+            // Ensure the assistant message item exists even if Qwen started with tool_calls
+            // (some Qwen streams begin with {content:"", role:null, tool_calls:[...]}).
+            if (!sentOutputItemAdded) {
+                const added = {
+                    type: 'response.output_item.added',
+                    output_index: 0,
+                    item: { type: 'message', id: outputItemId, status: 'in_progress', role: 'assistant', content: [] },
+                };
+                const addedJson = JSON.stringify(added);
+                controller.enqueue(encoder.encode(`data: ${addedJson}\n\n`));
+                sentOutputItemAdded = true;
+            }
+
+            // If we never emitted a content_part.added (e.g., tool_calls came before any text),
+            // synthesize it so that content_part.done/output_text.done are well-formed.
+            if (!sentContentPartAdded) {
+                const partAdded = {
+                    type: 'response.content_part.added',
+                    item_id: outputItemId,
+                    output_index: 0,
+                    content_index: 0,
+                    part: { type: 'output_text', text: '' },
+                };
+                const partAddedJson = JSON.stringify(partAdded);
+                controller.enqueue(encoder.encode(`data: ${partAddedJson}\n\n`));
+                sentContentPartAdded = true;
+            }
+            
+            const doneEvent = {
+                type: 'response.output_text.done',
+                item_id: outputItemId,
+                output_index: 0,
+                content_index: 0,
+                text: fullContent,
+            };
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(doneEvent)}\n\n`));
+
+            const contentPartDone = {
+                type: 'response.content_part.done',
+                item_id: outputItemId,
+                output_index: 0,
+                content_index: 0,
+                part: { type: 'output_text', text: fullContent },
+            };
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(contentPartDone)}\n\n`));
+
+            const outputDone = {
+                type: 'response.output_item.done',
+                output_index: 0,
+                item: {
+                    type: 'message',
+                    id: outputItemId,
+                    status: 'completed',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: fullContent }],
+                },
+            };
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(outputDone)}\n\n`));
+            
+            sentMessageDone = true;
+        }
+
+        function finalizeToolCalls(controller: ReadableStreamDefaultController, output: any[]) {
+            if (toolCallsFinalized) return;
+            for (const [callId, item] of toolCallItems.entries()) {
+                const finalArgs = item.arguments || '{}';
+
+                // First, emit function_call_arguments.done event
+                const argsDone = {
+                    type: 'response.function_call_arguments.done',
+                    item_id: item.itemId,
+                    output_index: item.outputIndex,
+                    call_id: callId,
+                    arguments: finalArgs,
+                };
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(argsDone)}\n\n`));
+
+                // Then emit output_item.done event
+                const callItem = {
+                    type: 'function_call',
+                    id: item.itemId,
+                    status: 'completed',
+                    call_id: callId,
+                    name: item.name || 'tool',
+                    arguments: finalArgs,
+                };
+                const callDone = {
+                    type: 'response.output_item.done',
+                    output_index: item.outputIndex,
+                    item: callItem,
+                };
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(callDone)}\n\n`));
+                output.push(callItem);
+            }
+            toolCallsFinalized = true;
+        }
+
+        function appendToolCallsToOutput(output: any[]) {
+            const entries = Array.from(toolCallItems.entries()).sort((a, b) => a[1].outputIndex - b[1].outputIndex);
+            for (const [callId, item] of entries) {
+                const finalArgs = item.arguments || '{}';
+                output.push({
+                    type: 'function_call',
+                    id: item.itemId,
+                    status: 'completed',
+                    call_id: callId,
+                    name: item.name || 'tool',
+                    arguments: finalArgs,
+                });
+            }
+        }
+
+        function processLine(line: string, controller: ReadableStreamDefaultController) {
+            if (!line.startsWith('data: ')) return;
+            const data = line.slice(6).trim();
+            if (data === '[DONE]' || data === '') return;
+
+            try {
+                const chunk = JSON.parse(data);
+                
+                // Debug: log the raw chunk from Qwen
+
+                // Capture metadata for the final Responses API object
+                if (typeof chunk?.model === 'string' && chunk.model.trim().length > 0) {
+                    responseModel = chunk.model;
+                }
+                if (typeof chunk?.created === 'number' && Number.isFinite(chunk.created)) {
+                    createdAt = chunk.created;
+                }
+                if (chunk?.usage && typeof chunk.usage === 'object') {
+                    const promptTokens =
+                        (chunk.usage as any).prompt_tokens ??
+                        (chunk.usage as any).promptTokens ??
+                        (chunk.usage as any).input_tokens ??
+                        (chunk.usage as any).inputTokens;
+                    const completionTokens =
+                        (chunk.usage as any).completion_tokens ??
+                        (chunk.usage as any).completionTokens ??
+                        (chunk.usage as any).output_tokens ??
+                        (chunk.usage as any).outputTokens;
+                    const totalTokens =
+                        (chunk.usage as any).total_tokens ??
+                        (chunk.usage as any).totalTokens ??
+                        ((typeof promptTokens === 'number' && typeof completionTokens === 'number')
+                            ? promptTokens + completionTokens
+                            : undefined);
+                    const cachedTokens =
+                        (chunk.usage as any).prompt_tokens_details?.cached_tokens ??
+                        (chunk.usage as any).cached_input_tokens ??
+                        (chunk.usage as any).cachedInputTokens;
+
+                    finalUsage = {
+                        input_tokens: typeof promptTokens === 'number' ? promptTokens : undefined,
+                        output_tokens: typeof completionTokens === 'number' ? completionTokens : undefined,
+                        total_tokens: typeof totalTokens === 'number' ? totalTokens : undefined,
+                        cached_input_tokens: typeof cachedTokens === 'number' ? cachedTokens : undefined,
+                    };
+                }
+                
+                // Handle empty choices array (some models send this for usage info)
+                if (!chunk.choices || chunk.choices.length === 0) {
+                    // This might be a usage-only chunk, skip it
+                    return;
+                }
+                
+                const delta = chunk.choices?.[0]?.delta;
+                const finishReason = chunk.choices?.[0]?.finish_reason;
+                
+                if (!delta && !finishReason) {
+                    return;
+                }
+
+                // Send initial events
+                if (!sentCreated) {
+                    const created = {
+                        type: 'response.created',
+                        response: {
+                            id: responseId,
+                            object: 'response',
+                            created_at: createdAt,
+                            model: responseModel || '',
+                            status: 'in_progress',
+                            error: null,
+                            incomplete_details: null,
+                            metadata: {},
+                            output: [],
+                        },
+                    };
+                    const createdJson = JSON.stringify(created);
+                    controller.enqueue(encoder.encode(`data: ${createdJson}\n\n`));
+                    sentCreated = true;
+                }
+
+                // Always announce the assistant message output item as early as possible.
+                // Do NOT gate on delta.content/delta.role: Qwen can start tool_calls with
+                // empty content and role=null, which would otherwise skip this event.
+                if (!sentOutputItemAdded) {
+                    const added = {
+                        type: 'response.output_item.added',
+                        output_index: 0,
+                        item: { type: 'message', id: outputItemId, status: 'in_progress', role: 'assistant', content: [] },
+                    };
+                    const addedJson = JSON.stringify(added);
+                    controller.enqueue(encoder.encode(`data: ${addedJson}\n\n`));
+                    sentOutputItemAdded = true;
+                }
+
+                // Send content delta
+                if (delta?.content) {
+                    // Emit content_part.added before first text delta
+                    if (!sentContentPartAdded) {
+                        const partAdded = {
+                            type: 'response.content_part.added',
+                            item_id: outputItemId,
+                            output_index: 0,
+                            content_index: 0,
+                            part: { type: 'output_text', text: '' },
+                        };
+                        const partAddedJson = JSON.stringify(partAdded);
+                        controller.enqueue(encoder.encode(`data: ${partAddedJson}\n\n`));
+                        sentContentPartAdded = true;
+                    }
+                    
+                    fullContent += delta.content;
+                    const deltaEvent = {
+                        type: 'response.output_text.delta',
+                        item_id: outputItemId,
+                        output_index: 0,
+                        content_index: 0,
+                        delta: delta.content,
+                    };
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify(deltaEvent)}\n\n`));
+                }
+                
+                // Handle tool calls (emit function_call output items + argument deltas)
+                if (delta?.tool_calls) {
+                    // Before emitting any function events, close the message item first
+                    // This matches CLIProxyAPI's behavior where message is closed before tool_calls
+                    if (sentOutputItemAdded && !sentMessageDone) {
+                        emitMessageDone(controller);
+                    }
+                    
+                    for (const toolCall of delta.tool_calls) {
+                        // Qwen sometimes sends tool_calls with index but no id in subsequent chunks
+                        // We need to track the mapping between index and callId
+                        // FIX: Handle the case where id comes in a later chunk
+                        
+                        const index = toolCall.index ?? 0; // Default to 0 if no index
+                        let callId = toolCall.id;
+                        const hintedName = toolNameHints?.byIndex.get(index) || toolNameHints?.defaultName;
+                        
+                        // Check if we already have a mapping for this index
+                        const existingCallId = toolCallIndices.get(index);
+                        
+                        if (callId && existingCallId && callId !== existingCallId) {
+                            // We have a real id now, but we already generated one
+                            // This shouldn't happen often, but if it does, use the existing one
+                            // to maintain consistency with already-emitted events
+                            callId = existingCallId;
+                        } else if (!callId && existingCallId) {
+                            // No id in this chunk, use the existing mapping
+                            callId = existingCallId;
+                        } else if (!callId && !existingCallId) {
+                            // No id and no existing mapping - generate one
+                            callId = `call_${Date.now()}_${index}`;
+                        }
+                        
+                        // Save/update the mapping between index and callId
+                        if (index !== undefined && callId) {
+                            toolCallIndices.set(index, callId);
+                        }
+
+                        let tracked = toolCallItems.get(callId);
+                        if (!tracked) {
+                            const outputIndex = 1 + toolCallItems.size; // after message
+                            tracked = {
+                                itemId: `fc_${callId}`, // Use fc_ prefix like CLIProxyAPI
+                                name: toolCall.function?.name || hintedName,
+                                arguments: '',
+                                outputIndex,
+                            };
+                            toolCallItems.set(callId, tracked);
+
+                            // Announce a function_call output item
+                            const addedCall = {
+                                type: 'response.output_item.added',
+                                output_index: outputIndex,
+                                item: {
+                                    type: 'function_call',
+                                    id: tracked.itemId,
+                                    status: 'in_progress',
+                                    call_id: callId,
+                                    name: tracked.name || toolCall.function?.name || hintedName || 'tool',
+                                    arguments: '',
+                                },
+                            };
+                            controller.enqueue(encoder.encode(`data: ${JSON.stringify(addedCall)}\n\n`));
+                        }
+
+                        if (toolCall.function?.name && !tracked.name) {
+                            tracked.name = toolCall.function.name;
+                        } else if (!tracked.name && hintedName) {
+                            tracked.name = hintedName;
+                        }
+
+                        if (toolCall.function?.arguments) {
+                            tracked.arguments += toolCall.function.arguments;
+                            const funcDelta = {
+                                type: 'response.function_call_arguments.delta',
+                                item_id: tracked.itemId,
+                                output_index: tracked.outputIndex,
+                                call_id: callId,
+                                delta: toolCall.function.arguments,
+                            };
+                            controller.enqueue(encoder.encode(`data: ${JSON.stringify(funcDelta)}\n\n`));
+                        }
+                    }
+                }
+                
+                // Handle finish_reason
+                if (finishReason === 'tool_calls' || finishReason === 'function_call') {
+                    // Some Qwen streams do not terminate promptly; finalize tool calls now so
+                    // the host can execute the tool instead of staying Pending.
+                    const output: any[] = [];
+                    finalizeToolCalls(controller, output);
+                }
+                
+                // Handle finish_reason: 'stop' - Qwen may not close the stream properly
+                // We need to emit the final events and close the stream ourselves
+                if (finishReason === 'stop') {
+                    
+                    // Build output array
+                    const output: any[] = [];
+                    
+                    // Close message item if not already done
+                    if (!sentMessageDone) {
+                        emitMessageDone(controller);
+                    }
+                    
+                    // Push message to output array
+                    output.push({
+                        type: 'message',
+                        id: outputItemId,
+                        status: 'completed',
+                        role: 'assistant',
+                        content: [{ type: 'output_text', text: fullContent }],
+                    });
+                    
+                    // Finalize any tool calls
+                    if (!toolCallsFinalized && toolCallItems.size > 0) {
+                        finalizeToolCalls(controller, output);
+                    } else if (toolCallItems.size > 0) {
+                        appendToolCallsToOutput(output);
+                    }
+                    
+                    // Emit response.completed
+                    const completed = {
+                        type: 'response.completed',
+                        response: {
+                            id: responseId,
+                            object: 'response',
+                            created_at: createdAt,
+                            model: responseModel || '',
+                            status: 'completed',
+                            error: null,
+                            incomplete_details: null,
+                            metadata: {},
+                            output,
+                            output_text: fullContent,
+                            text: fullContent, // Also include 'text' for compatibility
+                            usage: finalUsage,
+                        },
+                    };
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify(completed)}\n\n`));
+                    controller.close();
+                    return;
+                }
+            } catch {
+                // Skip malformed JSON
+            }
+        }
+
+        return new Response(stream, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: new Headers({
+                'content-type': 'text/event-stream',
+                'cache-control': 'no-cache',
+            }),
+        });
+    };
+
+    /**
+     * Transform non-streaming response from Chat Completions to Responses API format
+     */
+    const transformNonStreamingResponse = async (
+        response: Response,
+        toolNameHints?: { byIndex: Map<number, string>; defaultName?: string },
+        isToolSelectionRequest?: boolean
+    ): Promise<Response> => {
+        const text = await response.text();
+        
+        try {
+            const data = JSON.parse(text);
+            const choice = data.choices?.[0];
+            const message = choice?.message;
+            
+            if (!message) {
+                return new Response(text, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                });
+            }
+
+            const toolCallsCount = Array.isArray(message.tool_calls) ? message.tool_calls.length : 0;
+
+            const responseId = `resp_${data.id || Date.now()}`;
+            const outputItemId = `msg_${Date.now()}`;
+
+            // Build output array
+            const output: any[] = [];
+            
+            // Always include a message output item first (even if empty) to match Responses API expectations
+            let messageText = '';
+            if (typeof message.content === 'string') {
+                messageText = message.content;
+            } else if (Array.isArray(message.content)) {
+                messageText = message.content.map((p: any) => p?.text ?? '').join('');
+            } else if (message.content != null) {
+                messageText = String(message.content);
+            }
+
+            if (isToolSelectionRequest) {
+                let jsonCandidate = messageText.trim();
+                if (jsonCandidate.startsWith('```')) {
+                    const fenceIndex = jsonCandidate.indexOf('\n');
+                    if (fenceIndex !== -1) {
+                        jsonCandidate = jsonCandidate.slice(fenceIndex + 1);
+                    }
+                    const endFence = jsonCandidate.lastIndexOf('```');
+                    if (endFence !== -1) {
+                        jsonCandidate = jsonCandidate.slice(0, endFence);
+                    }
+                    jsonCandidate = jsonCandidate.trim();
+                }
+                if (jsonCandidate.startsWith('{') && jsonCandidate.endsWith('}')) {
+                    try {
+                        const parsedSelection = JSON.parse(jsonCandidate);
+                        const toolsField = Array.isArray(parsedSelection?.tools)
+                            ? parsedSelection.tools.join(',')
+                            : typeof parsedSelection?.tools === 'string'
+                                ? parsedSelection.tools
+                                : undefined;
+
+                        let toolsList: string[] | null = null;
+                        if (Array.isArray(parsedSelection?.tools)) {
+                            toolsList = parsedSelection.tools.filter((t: unknown) => typeof t === 'string') as string[];
+                        } else if (typeof parsedSelection?.tools === 'string') {
+                            toolsList = [parsedSelection.tools];
+                        }
+
+                        if (toolsList && toolsList.length > 0) {
+                            const hadBashOutput = toolsList.includes('BashOutput');
+                            let nextTools = [...toolsList]; // Clone to avoid mutation issues
+                            let changed = false;
+
+                            if (hadBashOutput) {
+                                nextTools = nextTools.filter(t => t !== 'BashOutput');
+                                changed = true;
+                                if (!nextTools.includes('Bash')) {
+                                    nextTools.unshift('Bash');
+                                }
+                            }
+
+                            if (changed) {
+                                parsedSelection.tools = nextTools;
+                                messageText = JSON.stringify(parsedSelection);
+                            }
+                        } else {
+                        }
+                    } catch (error) {
+                    }
+                } else {
+                }
+            }
+
+            output.push({
+                type: 'message',
+                id: outputItemId,
+                status: 'completed',
+                role: 'assistant',
+                content: [{
+                    type: 'output_text',
+                    text: messageText,
+                }],
+            });
+            
+            // Add tool calls if present
+            if (message.tool_calls && message.tool_calls.length > 0) {
+                for (let i = 0; i < message.tool_calls.length; i++) {
+                    const toolCall = message.tool_calls[i];
+                    const hintedName = toolNameHints?.defaultName;
+                    const rawCallId = toolCall.id;
+                    const callId = typeof rawCallId === 'string' && rawCallId.trim().length > 0
+                        ? rawCallId
+                        : `call_${Date.now()}_${i}`;
+                    const rawArgs = toolCall.function?.arguments;
+                    const args = typeof rawArgs === 'string' && rawArgs.trim().length > 0 ? rawArgs : '{}';
+                    output.push({
+                        type: 'function_call',
+                        id: `fc_${callId}`,
+                        status: 'completed',
+                        call_id: callId,
+                        name: toolCall.function?.name || hintedName || 'tool',
+                        arguments: args,
+                    });
+                }
+            }
+
+            const transformed: Record<string, unknown> = {
+                id: responseId,
+                object: 'response',
+                created_at: data.created || Math.floor(Date.now() / 1000),
+                model: data.model || '',
+                status: 'completed',
+                error: null,
+                incomplete_details: null,
+                metadata: {},
+                output,
+                output_text: messageText, // Top-level output_text for easy access (matches OpenAI Responses API)
+                usage: data.usage ? {
+                    input_tokens: data.usage.prompt_tokens,
+                    output_tokens: data.usage.completion_tokens,
+                    total_tokens: data.usage.total_tokens,
+                    cached_input_tokens: data.usage.prompt_tokens_details?.cached_tokens,
+                } : undefined,
+            };
+
+            return new Response(JSON.stringify(transformed), {
+                status: response.status,
+                statusText: response.statusText,
+                headers: new Headers({
+                    'content-type': 'application/json; charset=utf-8',
+                }),
+            });
+        } catch {
+            return new Response(text, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+            });
+        }
+    };
+
+    // =========================================================================
+    // Register Provider
+    // =========================================================================
+
+    const providerDisposable = providers.register({
+        id: 'qwen',
+        name: 'Qwen (Alibaba)',
+        description: 'Access Qwen AI models via your Qwen account',
+        authType: 'oauth',
+        // Note: Not specifying sdkType - Qwen uses standard OpenAI Chat Completions format
+        // which is different from the new OpenAI Responses API format
+
+        async initialize() {
+        },
+
+        async isAuthenticated() {
+            return tokenStore.hasValidToken();
+        },
+
+        async authenticate() {
+            try {
+                // Initiate device flow
+                const deviceFlow = await initiateDeviceFlow();
+
+                // Show user code and verification URL
+                ui.showNotification(
+                    `Please visit ${deviceFlow.verification_uri} and enter code: ${deviceFlow.user_code}`,
+                    { type: 'info', duration: 60000 }
+                );
+
+                // Also show in a more prominent way
+                const message = `
+🔐 **Qwen Authentication**
+
+1. Open: ${deviceFlow.verification_uri_complete || deviceFlow.verification_uri}
+2. Enter code: **${deviceFlow.user_code}**
+3. Authorize the application
+
+Waiting for authorization...
+                `.trim();
+
+
+                // Open browser to verification URL
+                if (deviceFlow.verification_uri_complete) {
+                    // Try to open the complete URL with code pre-filled
+                    try {
+                        await ui.openExternal(deviceFlow.verification_uri_complete);
+                    } catch {
+                        // Fallback to basic URL
+                        await ui.openExternal(deviceFlow.verification_uri);
+                    }
+                } else {
+                    await ui.openExternal(deviceFlow.verification_uri);
+                }
+
+                // Store pending device flow
+                await tokenStore.storePendingDeviceFlow({
+                    deviceCode: deviceFlow.device_code,
+                    codeVerifier: deviceFlow.code_verifier,
+                });
+
+                // Poll for token
+                const tokens = await pollForToken(
+                    deviceFlow.device_code,
+                    deviceFlow.code_verifier,
+                    () => {}
+                );
+
+                // Save tokens
+                await tokenStore.saveTokens(tokens);
+                await tokenStore.clearPendingDeviceFlow();
+
+                const emailInfo = tokens.email ? ` (${tokens.email})` : '';
+                ui.showNotification(`Successfully connected to Qwen${emailInfo}!`, { type: 'success' });
+
+                return { success: true };
+            } catch (error) {
+                const message = error instanceof Error ? error.message : 'Authentication failed';
+                ui.showError(`Authentication failed: ${message}`);
+                return { success: false, error: message };
+            }
+        },
+
+        async logout() {
+            await tokenStore.clearTokens();
+            ui.showNotification('Logged out from Qwen', { type: 'info' });
+        },
+
+        async getModels() {
+            // Return all supported models
+            return QWEN_MODELS.map((model) => ({
+                id: model.id,
+                name: model.name,
+                description: model.description,
+                contextWindow: model.contextWindow,
+                maxOutputTokens: model.maxOutputTokens,
+                capabilities: {
+                    streaming: true,
+                    reasoning: model.reasoning ?? false,
+                    vision: model.vision ?? false,
+                    functionCalling: model.functionCalling ?? true, // All Qwen models support function calling
+                },
+            }));
+        },
+
+        /**
+         * Returns SDK configuration for AI SDK's createOpenAI().
+         * Uses dummy API key since actual auth is handled in custom fetch.
+         * 
+         * Note: useResponsesAPI is set to true because we transform Chat Completions
+         * responses to Responses API format in our custom fetch wrapper.
+         */
+        async getSDKConfig() {
+            return {
+                apiKey: 'qwen-oauth', // Dummy key, actual auth in custom fetch
+                baseURL: getQwenBaseUrl(),
+                fetch: createQwenFetch(),
+                useResponsesAPI: true, // We transform responses to Responses API format
+            };
+        },
+    });
+
+    // =========================================================================
+    // Register Commands
+    // =========================================================================
+
+    const loginCommand = commands.register('qwen-auth.login', async () => {
+        const provider = providers.get('qwen');
+        if (provider) {
+            await provider.authenticate();
+        }
+    });
+
+    const logoutCommand = commands.register('qwen-auth.logout', async () => {
+        const provider = providers.get('qwen');
+        if (provider) {
+            await provider.logout();
+        }
+    });
+
+    const statusCommand = commands.register('qwen-auth.status', async () => {
+        const hasToken = tokenStore.hasValidToken();
+        const email = tokenStore.getEmail();
+
+        if (hasToken) {
+            const emailInfo = email ? ` (${email})` : '';
+            ui.showNotification(`Qwen: Authenticated${emailInfo}`, { type: 'info' });
+        } else {
+            ui.showNotification('Qwen: Not authenticated', { type: 'warning' });
+        }
+    });
+
+
+    // =========================================================================
+    // Return Activation
+    // =========================================================================
+
+    return {
+        dispose() {
+            providerDisposable.dispose();
+            loginCommand.dispose();
+            logoutCommand.dispose();
+            statusCommand.dispose();
+        },
+    };
+}

--- a/plugins/qwen-auth/manifest.json
+++ b/plugins/qwen-auth/manifest.json
@@ -1,0 +1,55 @@
+{
+    "id": "qwen-auth",
+    "name": "Qwen Auth",
+    "version": "1.0.1",
+    "description": "Use Alibaba Qwen AI models with Alma via OAuth Device Flow. Access Qwen models directly from your Qwen account.",
+    "author": {
+        "name": "laomeifun"
+    },
+    "main": "main.js",
+    "engines": {
+        "alma": "^0.1.0"
+    },
+    "type": "provider",
+    "permissions": [
+        "network:fetch",
+        "network:domain:chat.qwen.ai",
+        "network:domain:portal.qwen.ai",
+        "network:domain:dashscope.aliyuncs.com",
+        "providers:manage",
+        "notifications"
+    ],
+    "activationEvents": [
+        "onStartup"
+    ],
+    "contributes": {
+        "providers": [
+            {
+                "id": "qwen",
+                "name": "Qwen (Alibaba)",
+                "authType": "oauth"
+            }
+        ],
+        "commands": [
+            {
+                "id": "qwen-auth.login",
+                "title": "Login to Qwen (Alibaba)"
+            },
+            {
+                "id": "qwen-auth.logout",
+                "title": "Logout from Qwen"
+            },
+            {
+                "id": "qwen-auth.status",
+                "title": "Show Qwen Account Status"
+            }
+        ]
+    },
+    "keywords": [
+        "qwen",
+        "alibaba",
+        "oauth",
+        "ai",
+        "llm"
+    ]
+}


### PR DESCRIPTION
## Summary
Add a new `qwen-auth` plugin that provides authentication support for Qwen (通义千问) API.

## Features
- OAuth Device Flow authentication for Qwen API
- Automatic token refresh
- Model definitions for Qwen models (qwen3-coder, qwen3-coder-plus, qwen3-coder-flash, etc.)
- Request/Response transformation between OpenAI Responses API and Qwen Chat Completions API
- Streaming support with proper SSE handling
- Tool calling (function calling) support
- Alma Bridge prompt for better compatibility

## Files Added
- `plugins/qwen-auth/main.ts` - Main plugin entry point
- `plugins/qwen-auth/manifest.json` - Plugin manifest
- `plugins/qwen-auth/lib/auth.ts` - OAuth Device Flow implementation
- `plugins/qwen-auth/lib/models.ts` - Qwen model definitions
- `plugins/qwen-auth/lib/token-store.ts` - Token storage
- `plugins/qwen-auth/lib/alma-bridge.ts` - Alma Bridge prompt
- `plugins/qwen-auth/lib/types.ts` - TypeScript types
- `plugins/qwen-auth/README.md` - Documentation