### PR TITLE
Fix OpenAI Codex Auth Responses compatibility

### DIFF
--- a/plugins/openai-codex-auth/lib/codex-api.ts
+++ b/plugins/openai-codex-auth/lib/codex-api.ts
@@ -18,6 +18,10 @@ import { getBaseModelId, getReasoningEffort } from './models';
 // ============================================================================
 
 const CODEX_API_URL = 'https://chatgpt.com/backend-api/codex/responses';
+const FALLBACK_CODEX_INSTRUCTIONS = [
+    'You are ChatGPT, running as a coding agent in Alma.',
+    'Be concise, follow the user request, and use available tools when needed.',
+].join('\n');
 
 // ============================================================================
 // Request Types (from Alma's ProviderChatRequest)
@@ -115,6 +119,7 @@ export class CodexClient {
             model: baseModel,
             store: false, // Required: stateless mode
             stream: true, // Always stream for now
+            instructions: FALLBACK_CODEX_INSTRUCTIONS,
             input,
             include: ['reasoning.encrypted_content'], // Preserve reasoning context
         };
@@ -219,6 +224,10 @@ export class CodexClient {
 
                         try {
                             const event = JSON.parse(data);
+                            if (event.type === 'response.output_text.delta' && typeof event.delta === 'string') {
+                                controller.enqueue(encoder.encode(event.delta));
+                                continue;
+                            }
                             const fullText = extractTextFromEvent(event);
 
                             // Only send the delta (new portion of text)

--- a/plugins/openai-codex-auth/lib/codex-instructions.ts
+++ b/plugins/openai-codex-auth/lib/codex-instructions.ts
@@ -21,7 +21,7 @@ const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 /**
  * Model family type for prompt selection
  */
-export type ModelFamily = 'gpt-5.4' | 'gpt-5.3-codex' | 'gpt-5.3' | 'gpt-5.2-codex' | 'codex-max' | 'codex' | 'gpt-5.2' | 'gpt-5.1';
+export type ModelFamily = 'gpt-5.5' | 'gpt-5.4' | 'gpt-5.3-codex' | 'gpt-5.3' | 'gpt-5.2-codex' | 'codex-max' | 'codex' | 'gpt-5.2' | 'gpt-5.1';
 
 /**
  * Prompt file mapping for each model family
@@ -29,6 +29,7 @@ export type ModelFamily = 'gpt-5.4' | 'gpt-5.3-codex' | 'gpt-5.3' | 'gpt-5.2-cod
  * prompt files exist in the Codex CLI releases for these models.
  */
 const PROMPT_FILES: Record<ModelFamily, string> = {
+    'gpt-5.5': 'prompt.md',
     'gpt-5.4': 'prompt.md',
     'gpt-5.3-codex': 'gpt-5.3-codex_prompt.md',
     'gpt-5.3': 'prompt.md',
@@ -43,6 +44,7 @@ const PROMPT_FILES: Record<ModelFamily, string> = {
  * Cache file mapping for each model family
  */
 const CACHE_FILES: Record<ModelFamily, string> = {
+    'gpt-5.5': 'gpt-5.5-instructions.md',
     'gpt-5.4': 'gpt-5.4-instructions.md',
     'gpt-5.3-codex': 'gpt-5.3-codex-instructions.md',
     'gpt-5.3': 'gpt-5.3-instructions.md',
@@ -69,6 +71,9 @@ interface CacheMetadata {
  */
 export function getModelFamily(normalizedModel: string): ModelFamily {
     // Order matters - check more specific patterns first
+    if (normalizedModel.includes('gpt-5.5') || normalizedModel.includes('gpt 5.5')) {
+        return 'gpt-5.5';
+    }
     if (normalizedModel.includes('gpt-5.4') || normalizedModel.includes('gpt 5.4')) {
         return 'gpt-5.4';
     }

--- a/plugins/openai-codex-auth/lib/models.ts
+++ b/plugins/openai-codex-auth/lib/models.ts
@@ -94,6 +94,43 @@ export function buildModelsFromApiResponse(data: any): CodexModelInfo[] {
 
 export const CODEX_MODELS: CodexModelInfo[] = [
     // -------------------------------------------------------------------------
+    // GPT-5.5 (current frontier model - supports low/medium/high/xhigh)
+    // -------------------------------------------------------------------------
+    {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        description: 'GPT-5.5 - frontier model for complex coding and research',
+        baseModel: 'gpt-5.5',
+        reasoning: 'medium',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.5-low',
+        name: 'GPT-5.5 (Low Reasoning)',
+        baseModel: 'gpt-5.5',
+        reasoning: 'low',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.5-high',
+        name: 'GPT-5.5 (High Reasoning)',
+        baseModel: 'gpt-5.5',
+        reasoning: 'high',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.5-xhigh',
+        name: 'GPT-5.5 (XHigh Reasoning)',
+        baseModel: 'gpt-5.5',
+        reasoning: 'xhigh',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+
+    // -------------------------------------------------------------------------
     // GPT-5.4 (flagship frontier model - supports none/low/medium/high/xhigh)
     // -------------------------------------------------------------------------
     {
@@ -135,6 +172,43 @@ export const CODEX_MODELS: CodexModelInfo[] = [
         baseModel: 'gpt-5.4',
         reasoning: 'xhigh',
         contextWindow: 1050000,
+        maxOutputTokens: 128000,
+    },
+
+    // -------------------------------------------------------------------------
+    // GPT-5.4 Mini (fast/cost-efficient model - supports low/medium/high/xhigh)
+    // -------------------------------------------------------------------------
+    {
+        id: 'gpt-5.4-mini',
+        name: 'GPT-5.4 Mini',
+        description: 'GPT-5.4 Mini - fast and cost-efficient model',
+        baseModel: 'gpt-5.4-mini',
+        reasoning: 'medium',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.4-mini-low',
+        name: 'GPT-5.4 Mini (Low Reasoning)',
+        baseModel: 'gpt-5.4-mini',
+        reasoning: 'low',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.4-mini-high',
+        name: 'GPT-5.4 Mini (High Reasoning)',
+        baseModel: 'gpt-5.4-mini',
+        reasoning: 'high',
+        contextWindow: 400000,
+        maxOutputTokens: 128000,
+    },
+    {
+        id: 'gpt-5.4-mini-xhigh',
+        name: 'GPT-5.4 Mini (XHigh Reasoning)',
+        baseModel: 'gpt-5.4-mini',
+        reasoning: 'xhigh',
+        contextWindow: 400000,
         maxOutputTokens: 128000,
     },
 
@@ -559,7 +633,16 @@ export const CODEX_MODELS: CodexModelInfo[] = [
  * Get model info by ID (searches active model list)
  */
 export function getModelInfo(modelId: string): CodexModelInfo | undefined {
-    return getActiveModels().find(m => m.id === modelId);
+    const normalizedId = normalizeModelId(modelId);
+    return getActiveModels().find(m => m.id === normalizedId);
+}
+
+/**
+ * Alma can pass fully-qualified IDs such as
+ * openai-codex-auth:openai-codex:gpt-5.5. Codex only accepts the slug.
+ */
+export function normalizeModelId(modelId: string): string {
+    return modelId.includes(':') ? modelId.split(':').pop() || modelId : modelId;
 }
 
 /**
@@ -568,7 +651,7 @@ export function getModelInfo(modelId: string): CodexModelInfo | undefined {
  */
 export function getBaseModelId(modelId: string): string {
     const model = getModelInfo(modelId);
-    return model?.baseModel ?? modelId;
+    return model?.baseModel ?? normalizeModelId(modelId);
 }
 
 /**

--- a/plugins/openai-codex-auth/lib/token-store.ts
+++ b/plugins/openai-codex-auth/lib/token-store.ts
@@ -311,6 +311,29 @@ export class TokenStore {
         }
     }
 
+    /**
+     * Force-refresh an access token even when the cached expiry timestamp says
+     * it is still valid. ChatGPT can invalidate OAuth tokens before expiry.
+     */
+    async forceRefreshAccessToken(accountId = this.activeAccountId): Promise<string> {
+        if (!accountId) {
+            throw new Error('Not authenticated. Please login first.');
+        }
+
+        let pending = this.refreshPromises.get(accountId);
+        if (!pending) {
+            pending = this.doRefresh(accountId);
+            this.refreshPromises.set(accountId, pending);
+        }
+
+        try {
+            const tokens = await pending;
+            return tokens.access_token;
+        } finally {
+            this.refreshPromises.delete(accountId);
+        }
+    }
+
     private async doRefresh(accountId: string): Promise<CodexTokens> {
         const record = this.accounts.get(accountId);
         if (!record?.tokens.refresh_token) {

--- a/plugins/openai-codex-auth/main.ts
+++ b/plugins/openai-codex-auth/main.ts
@@ -49,7 +49,13 @@ const URL_PATHS = {
 const HTTP_STATUS = {
     NOT_FOUND: 404,
     TOO_MANY_REQUESTS: 429,
+    UNAUTHORIZED: 401,
 } as const;
+
+const FALLBACK_CODEX_INSTRUCTIONS = [
+    'You are ChatGPT, running as a coding agent in Alma.',
+    'Be concise, follow the user request, and use available tools when needed.',
+].join('\n');
 
 // ============================================================================
 // Plugin Activation
@@ -88,17 +94,64 @@ export async function activate(context: PluginContext): Promise<PluginActivation
             fullText += decoder.decode(value, { stream: true });
         }
 
-        // Parse SSE events to extract the final response
+        // Parse SSE events to extract the final response and rebuild output
+        // because the final response.completed payload can carry output: [].
         const lines = fullText.split('\n');
-        let finalResponse: unknown = null;
+        let finalResponse: any = null;
+        const outputByIndex = new Map<number, any>();
+
+        const ensureMessageItem = (outputIndex: number, itemId?: string) => {
+            let item = outputByIndex.get(outputIndex);
+            if (!item) {
+                item = {
+                    id: itemId,
+                    type: 'message',
+                    status: 'completed',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: '' }],
+                };
+                outputByIndex.set(outputIndex, item);
+            }
+            if (!Array.isArray(item.content)) item.content = [{ type: 'output_text', text: '' }];
+            if (!item.content[0]) item.content[0] = { type: 'output_text', text: '' };
+            return item;
+        };
 
         for (const line of lines) {
             if (line.startsWith('data: ')) {
                 try {
                     const data = JSON.parse(line.substring(6));
+                    if (typeof data.output_index === 'number') {
+                        if (data.type === 'response.output_item.added' && data.item) {
+                            outputByIndex.set(data.output_index, data.item);
+                        }
+                        if (data.type === 'response.output_item.done' && data.item) {
+                            outputByIndex.set(data.output_index, data.item);
+                        }
+                        if (data.type === 'response.output_text.delta') {
+                            const item = ensureMessageItem(data.output_index, data.item_id);
+                            const contentIndex = data.content_index ?? 0;
+                            if (!item.content[contentIndex]) item.content[contentIndex] = { type: 'output_text', text: '' };
+                            item.content[contentIndex].text = `${item.content[contentIndex].text ?? ''}${data.delta ?? ''}`;
+                        }
+                        if (data.type === 'response.output_text.done') {
+                            const item = ensureMessageItem(data.output_index, data.item_id);
+                            const contentIndex = data.content_index ?? 0;
+                            item.content[contentIndex] = {
+                                type: 'output_text',
+                                annotations: data.annotations ?? [],
+                                logprobs: data.logprobs ?? [],
+                                text: data.text ?? item.content[contentIndex]?.text ?? '',
+                            };
+                        }
+                        if (data.type === 'response.content_part.done' && data.part?.type === 'output_text') {
+                            const item = ensureMessageItem(data.output_index, data.item_id);
+                            const contentIndex = data.content_index ?? 0;
+                            item.content[contentIndex] = data.part;
+                        }
+                    }
                     if (data.type === 'response.done' || data.type === 'response.completed') {
                         finalResponse = data.response;
-                        break;
                     }
                 } catch {
                     // Skip malformed JSON
@@ -113,6 +166,12 @@ export async function activate(context: PluginContext): Promise<PluginActivation
                 statusText: response.statusText,
                 headers,
             });
+        }
+
+        if ((!Array.isArray(finalResponse.output) || finalResponse.output.length === 0) && outputByIndex.size > 0) {
+            finalResponse.output = Array.from(outputByIndex.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([, item]) => item);
         }
 
         // Return as plain JSON
@@ -162,6 +221,23 @@ export async function activate(context: PluginContext): Promise<PluginActivation
             statusText: 'Too Many Requests',
             headers,
         });
+    };
+
+    const getCodexInstructionsForRequest = async (model: string): Promise<string> => {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+            return await Promise.race([
+                getCodexInstructions(model),
+                new Promise<string>(resolve => {
+                    timeout = setTimeout(() => resolve(''), 1500);
+                }),
+            ]);
+        } catch (error) {
+            logger.warn(`Codex instructions fetch failed for ${model}:`, error);
+            return '';
+        } finally {
+            if (timeout) clearTimeout(timeout);
+        }
     };
 
     /**
@@ -376,7 +452,8 @@ export async function activate(context: PluginContext): Promise<PluginActivation
 
                     // Fetch Codex instructions from GitHub (matching opencode)
                     // These are cached with ETag for 15 minutes
-                    const codexInstructions = await getCodexInstructions(normalizedModel);
+                    const codexInstructions = await getCodexInstructionsForRequest(normalizedModel);
+                    const instructions = codexInstructions?.trim() || FALLBACK_CODEX_INSTRUCTIONS;
 
                     // Build reasoning config (matching official Codex CLI's build_responses_request)
                     const hasReasoning = reasoningEffort !== 'none';
@@ -400,10 +477,8 @@ export async function activate(context: PluginContext): Promise<PluginActivation
                         parallel_tool_calls: parsed.parallel_tool_calls ?? true, // Preserve from AI SDK or default true
                     };
 
-                    // Set Codex instructions (matching opencode's body.instructions = codexInstructions)
-                    if (codexInstructions) {
-                        transformedBody.instructions = codexInstructions;
-                    }
+                    // Codex backend requires non-empty instructions.
+                    transformedBody.instructions = instructions;
 
                     // Add reasoning config if enabled
                     if (reasoning) {
@@ -459,11 +534,29 @@ export async function activate(context: PluginContext): Promise<PluginActivation
             }
 
             // Step 6: Make the request
-            const response = await globalThis.fetch(codexUrl, {
+            let response = await globalThis.fetch(codexUrl, {
                 ...init,
                 body,
                 headers,
             });
+
+            if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+                const authErrorText = await response.clone().text().catch(() => '');
+                if (/token_invalidated|expired|unauthorized/i.test(authErrorText)) {
+                    try {
+                        logger.warn('Codex access token was rejected; refreshing and retrying once');
+                        const refreshedToken = await tokenStore.forceRefreshAccessToken(accountId);
+                        headers.set('Authorization', `Bearer ${refreshedToken}`);
+                        response = await globalThis.fetch(codexUrl, {
+                            ...init,
+                            body,
+                            headers,
+                        });
+                    } catch (error) {
+                        logger.error('Codex token refresh after 401 failed:', error);
+                    }
+                }
+            }
 
             // Step 7: Handle error response (matching opencode's handleErrorResponse)
             if (!response.ok) {
@@ -688,14 +781,14 @@ export async function activate(context: PluginContext): Promise<PluginActivation
         async fetchModels() {
             logger.info('Fetching available models from Codex API...');
             try {
-                const accessToken = await tokenStore.getValidAccessToken();
+                let accessToken = await tokenStore.getValidAccessToken();
                 const accountId = tokenStore.getAccountId();
                 if (!accountId) {
                     logger.warn('No account ID, returning default models');
                     return this.getModels();
                 }
 
-                const response = await globalThis.fetch(
+                const fetchModelList = () => globalThis.fetch(
                     `${CODEX_BASE_URL}/codex/models?client_version=1.0.0`,
                     {
                         headers: {
@@ -706,6 +799,21 @@ export async function activate(context: PluginContext): Promise<PluginActivation
                         },
                     },
                 );
+
+                let response = await fetchModelList();
+
+                if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+                    const authErrorText = await response.clone().text().catch(() => '');
+                    if (/token_invalidated|expired|unauthorized/i.test(authErrorText)) {
+                        try {
+                            logger.warn('Codex model fetch token was rejected; refreshing and retrying once');
+                            accessToken = await tokenStore.forceRefreshAccessToken(accountId);
+                            response = await fetchModelList();
+                        } catch (error) {
+                            logger.error('Codex token refresh before model fetch failed:', error);
+                        }
+                    }
+                }
 
                 if (!response.ok) {
                     logger.warn(`Failed to fetch models: ${response.status}`);


### PR DESCRIPTION
## Summary
- add current Codex model fallbacks for `gpt-5.5` and `gpt-5.4-mini`
- normalize fully-qualified Alma model IDs before sending requests to the Codex backend
- keep Codex Responses requests compatible with the current backend by always sending non-empty instructions
- retry once after the backend rejects an invalidated OAuth access token
- rebuild non-streaming output from current Responses SSE text events

## Background
While testing the OpenAI Codex Auth provider in Alma, generation could fail with `AI_APICallError: Bad Request` even after OAuth login succeeded. Live probing showed two compatibility issues with the current Codex backend:

- `/backend-api/codex/responses` rejects requests without `instructions` with `Instructions are required`.
- Alma can pass a fully-qualified model string such as `openai-codex-auth:openai-codex:gpt-5.5`; the Codex backend expects only the model slug.

The model discovery endpoint also currently returns `gpt-5.5` and `gpt-5.4-mini`, so the fallback model list should include them when live discovery is unavailable.

## Testing
- Bundled `plugins/openai-codex-auth/main.ts` with Alma's bundled esbuild.
- Ran `git diff --check`.
- Verified locally in Alma that:
  - `plugin:openai-codex-auth:openai-codex:gpt-5.5` generated successfully.
  - `plugin:openai-codex-auth:openai-codex:gpt-5.5-high` generated successfully.
  - model listing exposes `gpt-5.5` and `gpt-5.4-mini` variants.
